### PR TITLE
Should never use async void

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ public static IWebHost BuildWebHost(string[] args)
 Open the Electron Window in the Startup.cs file: 
 
 ```csharp
-public async void Configure(IApplicationBuilder app, IHostingEnvironment env)
+public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
     if (env.IsDevelopment())
     {
@@ -60,7 +60,7 @@ public async void Configure(IApplicationBuilder app, IHostingEnvironment env)
     });
 
     // Open the Electron-Window here
-    await Electron.WindowManager.CreateWindowAsync();
+    Task.Run(async () => await Electron.WindowManager.CreateWindowAsync());
 }
 ```
 


### PR DESCRIPTION
Should never use async void

I tried other scenario but that seems to endup in deadlock or the WebHostBuilder is not happy
I ended up avoiding 

Not working so far:
```csharp
public async Task Configure(IApplicationBuilder app, IHostingEnvironment env)
{
  await Electron.WindowManager.CreateWindowAsync()
}
```

```csharp
public void Configure(IApplicationBuilder app, IHostingEnvironment env)
{
  Electron.WindowManager.CreateWindowAsync().Start()
}
```

```csharp
public void Configure(IApplicationBuilder app, IHostingEnvironment env)
{
  Electron.WindowManager.CreateWindowAsync().RunSynchronously()
}
```