### PR TITLE
Remove old build.cmd

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,0 @@
-cd ElectronNET.WebApp
-dotnet restore
-dotnet publish -r win10-x64 --output ../ElectronNET.Host/bin/
-
-cd ..\ElectronNET.Host
-electron-packager . --platform=win32 --arch=x64 --out="C:\Users\Gregor\Documents\Visual Studio 2017\Projects\ElectronNET\ElectronNET.WebApp\bin\desktop" --overwrite


### PR DESCRIPTION
It currently confuses user and the functionality is part of the buildAll.cmds and electronize build