### PR TITLE
Move to generic RIDs

### DIFF
--- a/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -41,7 +41,7 @@ namespace ElectronNET.CLI.Commands
                 switch (desiredPlatform)
                 {
                     case "win":
-                        netCorePublishRid = "win10-x64";
+                        netCorePublishRid = "win-x64";
                         electronPackerPlatform = "win32";
                         break;
                     case "osx":
@@ -49,14 +49,14 @@ namespace ElectronNET.CLI.Commands
                         electronPackerPlatform = "darwin";
                         break;
                     case "linux":
-                        netCorePublishRid = "ubuntu-x64";
+                        netCorePublishRid = "linux-x64";
                         electronPackerPlatform = "linux";
                         break;
                     default:
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
                         {
                             desiredPlatform = "win";
-                            netCorePublishRid = "win10-x64";
+                            netCorePublishRid = "win-x64";
                             electronPackerPlatform = "win32";
                         }
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
@@ -68,7 +68,7 @@ namespace ElectronNET.CLI.Commands
                         if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                         {
                             desiredPlatform = "linux";
-                            netCorePublishRid = "ubuntu-x64";
+                            netCorePublishRid = "linux-x64";
                             electronPackerPlatform = "linux";
                         }
 

--- a/ElectronNET.CLI/Commands/StartElectronCommand.cs
+++ b/ElectronNET.CLI/Commands/StartElectronCommand.cs
@@ -47,7 +47,7 @@ namespace ElectronNET.CLI.Commands
                 }
 
                 string tempBinPath = Path.Combine(tempPath, "bin");
-                ProcessHelper.CmdExecute($"dotnet publish -r win10-x64 --output \"{tempBinPath}\"", aspCoreProjectPath);
+                ProcessHelper.CmdExecute($"dotnet publish -r win-x64 --output \"{tempBinPath}\"", aspCoreProjectPath);
 
                 EmbeddedFileHelper.DeployEmbeddedFile(tempPath, "main.js");
                 EmbeddedFileHelper.DeployEmbeddedFile(tempPath, "package.json");

--- a/ElectronNET.WebApp/ElectronNET.WebApp.csproj
+++ b/ElectronNET.WebApp/ElectronNET.WebApp.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <RuntimeIdentifiers>win10-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Controllers\ManageWindowsController.cs" />

--- a/start.cmd
+++ b/start.cmd
@@ -2,7 +2,7 @@ echo Bundle ASP.NET Core Project into EXE
 
 cd ElectronNET.WebApp
 dotnet restore
-dotnet publish -r win10-x64 --output ../ElectronNET.Host/bin/
+dotnet publish -r win-x64 --output ../ElectronNET.Host/bin/
 
 echo Start Electron with bundled EXE
 cd ..\ElectronNET.Host

--- a/start.sh
+++ b/start.sh
@@ -2,7 +2,7 @@ echo Bundle ASP.NET Core Project into EXE
 
 cd ElectronNET.WebApp
 dotnet restore
-dotnet publish -r osx.10.11-x64 --output ../ElectronNET.Host/bin/
+dotnet publish -r osx-x64 --output ../ElectronNET.Host/bin/
 
 echo Start Electron with bundled EXE
 cd ../ElectronNET.Host


### PR DESCRIPTION
In .NET Core 2.0, generic RID's should be used to enable broadest reach for the resulting published app. This change just moves all the scripts/projects to use that instead.