### PR TITLE
Add link to Readme explaining macOS build issues on Windows Machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ The end result should be an electron app under your __/bin/desktop__ folder.
 There is a React/Typescript/MobX starter kit at https://github.com/yoDon/Electron.NET-React-Typescript-MobX
 
 ### Note
-> macOS builds on Windows are currently not supported, because the build just hangs, but I'm not sure why. The macOS builds works on Linux/macOS however.
+> macOS builds can't be created on Windows machines because they require symlinks that aren't supported on Windows (per [this Electron issue](https://github.com/electron-userland/electron-packager/issues/71)). macOS builds can be produced on either Linux or macOS machines.
 
 # Working with this Repo
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,10 @@ In your default setting we just build the application for the OS you are running
 
 The end result should be an electron app under your __/bin/desktop__ folder.
 
+## Starter kits
+
+There is a React/Typescript/MobX starter kit at https://github.com/yoDon/Electron.NET-React-Typescript-MobX
+
 ### Note
 > macOS builds on Windows are currently not supported, because the build just hangs, but I'm not sure why. The macOS builds works on Linux/macOS however.
 


### PR DESCRIPTION
Add more detail to the spot in the Readme that currently says "the build just hangs, but I'm not sure why" re: trying to build for macOS on Windows. It turns out this is a fundamental Electron issue they've looked into considerably and have not been able to resolve (other than "make macOS builds on Macs or Linux machines").