### PR TITLE
added support for linux-arm platform

### DIFF
--- a/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
+++ b/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
@@ -33,6 +33,10 @@ namespace ElectronNET.CLI.Commands.Actions
                     netCorePublishRid = "linux-x64";
                     electronPackerPlatform = "linux";
                     break;
+                case "linux-arm":
+                    netCorePublishRid = "linux-arm";
+                    electronPackerPlatform = "linux";
+                    break;
                 case "custom":
                     var splittedSpecified = specifiedPlatfromFromCustom.Split(';');
                     netCorePublishRid = splittedSpecified[0];

--- a/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -48,7 +48,7 @@ namespace ElectronNET.CLI.Commands
                 string specifiedFromCustom = string.Empty;
                 if (desiredPlatform == "custom" && parser.Arguments[_paramTarget].Length > 1)
                 {
-                    specifiedFromCustom = parser.Arguments["target"][1];
+                    specifiedFromCustom = parser.Arguments[_paramTarget][1];
                 }
 
                 string configuration = "Release";


### PR DESCRIPTION
Hi,

as discussed in the issue #118 . Direct support for linux-arm added. Platform for packager is still linux. electron-arch gets already piped through correctly.