### PR TITLE
CLI is now a dotnet tool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: csharp
 mono: none
 dotnet: 2.1.300
 before_script:
+  - export PATH="$PATH:/home/travis/.dotnet/tools"
   - npm install electron-packager --global
 script:
   - ./buildAll.sh

--- a/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -1,9 +1,9 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
-    <AssemblyName>dotnet-electronize</AssemblyName>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <AssemblyName>electronize</AssemblyName>
     
     <PackageType>DotnetCliTool</PackageType>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
@@ -21,6 +21,7 @@ This package contains the dotnet tooling to electronize your application.</Descr
     <PackageTags>electron aspnetcore</PackageTags>
     <PackageReleaseNotes>Changelog: https://github.com/ElectronNET/Electron.NET/blob/master/Changelog.md</PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/ElectronNET/Electron.NET/master/assets/images/electron.net-logo-square.png</PackageIconUrl>
+    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ElectronNET.WebApp/ElectronNET.WebApp.csproj
+++ b/ElectronNET.WebApp/ElectronNET.WebApp.csproj
@@ -26,9 +26,6 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <DotNetCliToolReference Include="ElectronNET.CLI" Version="*" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\ElectronNET.API\ElectronNET.API.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/NuGet.config
+++ b/NuGet.config
@@ -2,8 +2,7 @@
 <configuration>
 <packageSources>
     <clear />
-    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
     <add key="LocalDev" value="artifacts" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
 </packageSources>
-
 </configuration>

--- a/buildAll.cmd
+++ b/buildAll.cmd
@@ -16,19 +16,22 @@ dotnet build
 
 echo "Invoke electronize build in WebApp Demo"
 
+echo "Install CLI"
+
+dotnet tool uninstall ElectronNET.CLI -g
+dotnet tool install ElectronNET.CLI -g
 
 echo "/target xxx (dev-build)"
-dotnet "../ElectronNET.CLI/bin/Debug/netcoreapp2.0/dotnet-electronize.dll" build /target custom win7-x86;win32 /dotnet-configuration Debug /electron-arch ia32  /electron-params "--prune=true "
-
+electronize build /target custom win7-x86;win32 /dotnet-configuration Debug /electron-arch ia32  /electron-params "--prune=true "
 
 echo "/target win (dev-build)"
-dotnet "../ElectronNET.CLI/bin/Debug/netcoreapp2.0/dotnet-electronize.dll" build /target win
+electronize build /target win
 
 echo "/target linux (dev-build)"
-dotnet "../ElectronNET.CLI/bin/Debug/netcoreapp2.0/dotnet-electronize.dll" build /target linux
+electronize build /target linux
 
 echo "/target custom win7-x86;win32 (dev-build)"
-dotnet "../ElectronNET.CLI/bin/Debug/netcoreapp2.0/dotnet-electronize.dll" build /target custom win7-x86;win32
+electronize build /target custom win7-x86;win32
 
 
 :: Be aware, that for non-electronnet-dev environments the correct 

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -17,18 +17,23 @@ cd $dir/ElectronNET.WebApp
 dotnet restore
 dotnet build
 
+echo "Install CLI as dotnet tool"
+
+dotnet tool uninstall ElectronNET.CLI -g
+dotnet tool install ElectronNET.CLI -g
+
 echo "Invoke electronize build in WebApp Demo"
 echo "/target win (dev-build)"
-dotnet "$dir/ElectronNET.CLI/bin/Debug/netcoreapp2.0/dotnet-electronize.dll" build /target win
+electronize build /target win
 
 echo "/target linux (dev-build)"
-dotnet "$dir/ElectronNET.CLI/bin/Debug/netcoreapp2.0/dotnet-electronize.dll" build /target linux
+electronize build /target linux
 
 echo "/target osx (dev-build)"
-dotnet "$dir/ElectronNET.CLI/bin/Debug/netcoreapp2.0/dotnet-electronize.dll" build /target osx
+electronize build /target osx
 
 echo "/target custom win7-x86;win32 (dev-build)"
-dotnet "$dir/ElectronNET.CLI/bin/Debug/netcoreapp2.0/dotnet-electronize.dll" build /target custom "win7-x86;win32"
+electronize build /target custom "win7-x86;win32"
 
 # Be aware, that for non-electronnet-dev environments the correct 
 # invoke command would be dotnet electronize ...


### PR DESCRIPTION
Moving from the "old" way to the new proposed dotnet tool world.

Will enable us to install "electronize" on as a "global dotnet tool".

e.g. just invoke it from the cmd via "electronize ..."