### PR TITLE
Reduce chance of detecting false positives when scanning subprocesses for errors.

### DIFF
--- a/ElectronNET.CLI/ProcessHelper.cs
+++ b/ElectronNET.CLI/ProcessHelper.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
 
 namespace ElectronNET.CLI
 {
     public class ProcessHelper
     {
+        private readonly static Regex ErrorRegex = new Regex(@"\berror\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
         public static int CmdExecute(string command, string workingDirectoryPath, bool output = true, bool waitForExit = true)
         {
             using (Process cmd = new Process())
@@ -44,7 +47,7 @@ namespace ElectronNET.CLI
                         // 1 if something fails
                         if (e != null && string.IsNullOrWhiteSpace(e.Data) == false)
                         {
-                            if (e.Data.ToLowerInvariant().Contains("error"))
+                            if (ErrorRegex.IsMatch(e.Data))
                             {
                                 returnCode = 1;
                             }
@@ -63,7 +66,7 @@ namespace ElectronNET.CLI
                         // 1 if something fails
                         if (e != null && string.IsNullOrWhiteSpace(e.Data) == false)
                         {
-                            if (e.Data.ToLowerInvariant().Contains("error"))
+                            if (ErrorRegex.IsMatch(e.Data))
                             {
                                 returnCode = 1;
                             }


### PR DESCRIPTION
Fixes #160

The problem is that `ng build` logs lines like the following:

```
20% building modules 90/102 modules 12 active 
...modules\\rxjs\\_esm5\\util\\EmptyError.js
```

The original code detects this as an error, unintentionally. The problem is compounded by the fact that the build process uses backspace characters, which means the "offending" line is invisible to end users.

This fix doesn't address the fact that scanning for "error" is a horrible hack, but I'm sure you've already explored the alternatives. Instead, I've made the smallest change possible that will continue to detect any likely error, while ignoring these problematic files. Fortunately, no file called "error.js" is installed, at least when I tested (Windowx x64, netcoreapp**2.1**, default new angular project).