### PR TITLE
Call electronize from the Path instead of via dotnet in launchSettings.json

### DIFF
--- a/ElectronNET.CLI/Commands/InitCommand.cs
+++ b/ElectronNET.CLI/Commands/InitCommand.cs
@@ -100,15 +100,16 @@ namespace ElectronNET.CLI.Commands
 
             string launchSettingText = File.ReadAllText(launchSettingFile);
 
-            if (launchSettingText.Contains("electronize start") == false)
+            if (launchSettingText.Contains("\"executablePath\": \"electronize\"") == false)
             {
                 StringBuilder debugProfileBuilder = new StringBuilder();
                 debugProfileBuilder.AppendLine("profiles\": {");
-                debugProfileBuilder.AppendLine("\"Electron.NET App\": {");
-                debugProfileBuilder.AppendLine("\"commandName\": \"Executable\",");
-                debugProfileBuilder.AppendLine("\"executablePath\": \"C:\\\\Program Files\\\\dotnet\\\\dotnet.exe\",");
-                debugProfileBuilder.AppendLine("\"commandLineArgs\": \"electronize start\"");
-                debugProfileBuilder.AppendLine("},");
+                debugProfileBuilder.AppendLine("    \"Electron.NET App\": {");
+                debugProfileBuilder.AppendLine("      \"commandName\": \"Executable\",");
+                debugProfileBuilder.AppendLine("      \"executablePath\": \"electronize\",");
+                debugProfileBuilder.AppendLine("      \"commandLineArgs\": \"start\",");
+                debugProfileBuilder.AppendLine("      \"workingDirectory\": \".\"");
+                debugProfileBuilder.AppendLine("    },");
 
                 launchSettingText = launchSettingText.Replace("profiles\": {", debugProfileBuilder.ToString());
                 File.WriteAllText(launchSettingFile, launchSettingText);

--- a/ElectronNET.WebApp/Properties/launchSettings.json
+++ b/ElectronNET.WebApp/Properties/launchSettings.json
@@ -8,6 +8,13 @@
     }
   },
   "profiles": {
+    "Electron.NET App": {
+      "commandName": "Executable",
+      "executablePath": "electronize",
+      "commandLineArgs": "start",
+      "workingDirectory": "."
+    },
+
     "IIS Express": {
       "commandName": "IISExpress",
       "environmentVariables": {
@@ -22,10 +29,5 @@
       },
       "applicationUrl": "http://localhost:50395/"
     },
-    "Electron.NET App": {
-      "commandName": "Executable",
-      "executablePath": "C:\\Program Files\\dotnet\\dotnet.exe",
-      "commandLineArgs": "electronize start"
-    }
   }
 }


### PR DESCRIPTION
I've noticed that when calling **electronize init**
The default behaviour is to modify launchSettings.json to add a profile to launch electronize via dotnet
However this would only work if electronize.exe was renamed to dotnet-electronize.exe in the tools directory

I've modified the init routine and the launchSettings.json of the example web app
to instead call electronize directly from the Path
Typically under windows it's located under C:\Users\UserName\\.dotnet\tools\electronize.exe
which seems to be on my path by default.
For info the WorkingDirectory parameter of "." is needed to place the working directory in the same directory as the .csproj file instead of somewhere inside a bin/Debug folder.

The only other way to fix this would be to rename electronize.exe to dotnet-electronize.exe when it's installed as a tool
```
dotnet tool install ElectronNET.CLI -g
```

see https://github.com/natemcmaster/dotnet-tools