### PR TITLE
Fix ASP.NET backend listening on 0.0.0.0

### DIFF
--- a/ElectronNET.API/Entities/WebPreferences.cs
+++ b/ElectronNET.API/Entities/WebPreferences.cs
@@ -15,10 +15,10 @@ namespace ElectronNET.API.Entities
         public bool DevTools { get; set; } = true;
 
         /// <summary>
-        /// Whether node integration is enabled. Default is true.
+        /// Whether node integration is enabled. Default is false.
         /// </summary>
-        [DefaultValue(true)]
-        public bool NodeIntegration { get; set; } = true;
+        [DefaultValue(false)]
+        public bool NodeIntegration { get; set; } = false;
 
         /// <summary>
         /// Whether node integration is enabled in web workers. Default is false.

--- a/ElectronNET.API/Entities/WebPreferences.cs
+++ b/ElectronNET.API/Entities/WebPreferences.cs
@@ -15,10 +15,10 @@ namespace ElectronNET.API.Entities
         public bool DevTools { get; set; } = true;
 
         /// <summary>
-        /// Whether node integration is enabled. Default is false.
+        /// Whether node integration is enabled. Required to enable IPC. Default is true.
         /// </summary>
-        [DefaultValue(false)]
-        public bool NodeIntegration { get; set; } = false;
+        [DefaultValue(true)]
+        public bool NodeIntegration { get; set; } = true;
 
         /// <summary>
         /// Whether node integration is enabled in web workers. Default is false.

--- a/ElectronNET.API/WebHostBuilderExtensions.cs
+++ b/ElectronNET.API/WebHostBuilderExtensions.cs
@@ -31,7 +31,7 @@ namespace ElectronNET.API
             if(HybridSupport.IsElectronActive)
             {
                 builder.UseContentRoot(AppDomain.CurrentDomain.BaseDirectory)
-                    .UseUrls("http://localhost:" + BridgeSettings.WebPort);
+                    .UseUrls("http://127.0.0.1:" + BridgeSettings.WebPort);
             }
 
             return builder;

--- a/README.md
+++ b/README.md
@@ -254,3 +254,16 @@ If you still use this version you will need to invoke it like this:
 ```
 dotnet electronize ...
 ```
+
+## Node Integration
+Electron.NET requires Node Integration to be enabled for IPC to function.  If you are not using the IPC functionality you can disable Node Integration like so:
+
+```csharp
+WebPreferences wp = new WebPreferences();
+wp.NodeIntegration = false;
+BrowserWindowOptions browserWindowOptions = new BrowserWindowOptions
+{
+    WebPreferences = wp
+}
+
+```

--- a/buildReleaseNuGetPackages.cmd
+++ b/buildReleaseNuGetPackages.cmd
@@ -1,13 +1,14 @@
+set ENETVER=5.22.12
 echo "Start building Electron.NET dev stack..."
 echo "Restore & Build API"
 cd ElectronNet.API
 dotnet restore
-dotnet build --configuration Release --force /property:Version=5.22.12
-dotnet pack /p:Version=5.22.12 --configuration Release --force --output "%~dp0artifacts"
+dotnet build --configuration Release --force /property:Version=%ENETVER%
+dotnet pack /p:Version=%ENETVER% --configuration Release --force --output "%~dp0artifacts"
 cd ..
 echo "Restore & Build CLI"
 cd ElectronNet.CLI
 dotnet restore
-dotnet build --configuration Release --force /property:Version=5.22.12
-dotnet pack /p:Version=5.22.12 --configuration Release --force --output "%~dp0artifacts"
+dotnet build --configuration Release --force /property:Version=%ENETVER%
+dotnet pack /p:Version=%ENETVER% --configuration Release --force --output "%~dp0artifacts"
 cd ..


### PR DESCRIPTION
_Why this change?_
Default behavior for windows appears to be to resolve ```localhost``` to ```0.0.0.0``` which causes the Windows firewall to get triggered, but also exposes the ASP.NET backend to remote access which opens up the app to RCE risks unnecessarily.

_Also_
1. Add a comment for why NodeIntegration is true.

2. The version used in the build script is now a variable, only needs to be changed once.

I've validated that with this changed behavior, our App, [Attack Surface Analyzer](github.com/Microsoft/AttackSurfaceAnalyzer), encounters no issues. I'm unable to test it on the WebApp as the version on master currently does not work for me (even without my changes).