### PR TITLE
Fixed bug: Electron tray icon TypeError

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,16 @@
 # Not released
 
+# 5.22.14
+
+ElectronNET.CLI:
+
+* Fixed bug: Electron tray icon TypeError ([Electron original issue](https://github.com/electron/electron/issues/7657))
+* Fixed bug: Wrong tray icon path in the application built via `electronize build` command
+
+ElectronNET.WebApp:
+
+* Fixed usage of the `Electron.Tray.Show` according fixed bugs in the ElectronNET.CLI
+
 
 # Released
 

--- a/ElectronNET.Host/api/tray.js
+++ b/ElectronNET.Host/api/tray.js
@@ -52,8 +52,8 @@ module.exports = (socket) => {
         addMenuItemClickConnector(menu.items, (id) => {
             electronSocket.emit('trayMenuItemClicked', id);
         });
-        const imagePath = path.join(__dirname.replace('api', ''), 'bin', image);
-        tray = new electron_1.Tray(imagePath);
+        const trayIcon = electron_1.nativeImage.createFromPath(image);
+        tray = new electron_1.Tray(trayIcon);
         tray.setContextMenu(menu);
     });
     socket.on('tray-destroy', () => {

--- a/ElectronNET.Host/api/tray.ts
+++ b/ElectronNET.Host/api/tray.ts
@@ -60,9 +60,9 @@ export = (socket: SocketIO.Socket) => {
             electronSocket.emit('trayMenuItemClicked', id);
         });
 
-        const imagePath = path.join(__dirname.replace('api', ''), 'bin', image);
+        const trayIcon = nativeImage.createFromPath(image);
 
-        tray = new Tray(imagePath);
+        tray = new Tray(trayIcon);
         tray.setContextMenu(menu);
     });
 

--- a/ElectronNET.WebApp/Controllers/TrayController.cs
+++ b/ElectronNET.WebApp/Controllers/TrayController.cs
@@ -1,11 +1,21 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using System.IO;
+using Microsoft.AspNetCore.Mvc;
 using ElectronNET.API;
 using ElectronNET.API.Entities;
+using Microsoft.AspNetCore.Hosting;
 
 namespace ElectronNET.WebApp.Controllers
 {
     public class TrayController : Controller
     {
+        private readonly IHostingEnvironment _env;
+
+        public TrayController(IHostingEnvironment env)
+        {
+            _env = env;
+        }
+
+
         public IActionResult Index()
         {
             if (HybridSupport.IsElectronActive)
@@ -21,7 +31,7 @@ namespace ElectronNET.WebApp.Controllers
                             Click = () => Electron.Tray.Destroy()
                         };
 
-                        Electron.Tray.Show("/Assets/electron_32x32.png", menu);
+                        Electron.Tray.Show(Path.Combine(_env.ContentRootPath, "Assets/electron_32x32.png"), menu);
                         Electron.Tray.SetToolTip("Electron Demo in the tray.");
                     }
                     else

--- a/ElectronNET.WebApp/ElectronNET.WebApp.csproj
+++ b/ElectronNET.WebApp/ElectronNET.WebApp.csproj
@@ -11,7 +11,6 @@
     <Content Remove="Views\Windows\HandleErrorCrashes.cshtml" />
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="Assets\" />
     <Folder Include="wwwroot\assets\" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
The main idea is: the developer of the end-user application should take care of the tray icon path, not the ElectronNET framework.