### PR TITLE
fix issue #301

### DIFF
--- a/ElectronNET.API/BrowserWindow.cs
+++ b/ElectronNET.API/BrowserWindow.cs
@@ -1940,6 +1940,14 @@ namespace ElectronNET.API
         }
 
         /// <summary>
+        /// Remove the window's menu bar.
+        /// </summary>
+        public void RemoveMenu()
+        {
+            BridgeConnector.Socket.Emit("browserWindowRemoveMenu", Id);
+        }
+
+        /// <summary>
         /// Sets progress value in progress bar. Valid range is [0, 1.0]. Remove progress
         /// bar when progress smaler as 0; Change to indeterminate mode when progress bigger as 1. On Linux
         /// platform, only supports Unity desktop environment, you need to specify the

--- a/ElectronNET.Host/api/browserWindows.js
+++ b/ElectronNET.Host/api/browserWindows.js
@@ -440,6 +440,9 @@ module.exports = (socket, app) => {
         }
         getWindowById(id).setMenu(menu);
     });
+    socket.on('browserWindowRemoveMenu', (id) => {
+        getWindowById(id).removeMenu();
+    });
     function addMenuItemClickConnector(menuItems, callback) {
         menuItems.forEach((item) => {
             if (item.submenu && item.submenu.items.length > 0) {

--- a/ElectronNET.Host/api/browserWindows.ts
+++ b/ElectronNET.Host/api/browserWindows.ts
@@ -573,6 +573,10 @@ export = (socket: SocketIO.Socket, app: Electron.App) => {
         getWindowById(id).setMenu(menu);
     });
 
+    socket.on('browserWindowRemoveMenu', (id) => {
+        getWindowById(id).removeMenu();
+    });
+
     function addMenuItemClickConnector(menuItems, callback) {
         menuItems.forEach((item) => {
             if (item.submenu && item.submenu.items.length > 0) {


### PR DESCRIPTION
Fixes issue #301 by adding Electron API [win.removeMenu()](https://electronjs.org/docs/api/browser-window#winremovemenu-linux-windows), extending Electron.NET API by adding `BrowserWindow.RemoveMenu()` method