### PR TITLE
Fix `buildAll.cmd` and `buildAll.sh` when running on clear repo

### DIFF
--- a/buildAll.cmd
+++ b/buildAll.cmd
@@ -22,7 +22,7 @@ dotnet tool uninstall ElectronNET.CLI -g
 dotnet tool install ElectronNET.CLI -g
 
 echo "/target xxx (dev-build)"
-electronize build /target custom win7-x86;win32 /dotnet-configuration Debug /electron-arch ia32  /electron-params "--prune=true "
+electronize build /target custom win7-x86;win /dotnet-configuration Debug /electron-arch ia32  /electron-params "--prune=true "
 
 echo "/target win (dev-build)"
 electronize build /target win
@@ -30,8 +30,8 @@ electronize build /target win
 echo "/target linux (dev-build)"
 electronize build /target linux
 
-echo "/target custom win7-x86;win32 (dev-build)"
-electronize build /target custom win7-x86;win32
+echo "/target custom win7-x86;win (dev-build)"
+electronize build /target custom win7-x86;win
 
 
 :: Be aware, that for non-electronnet-dev environments the correct 

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -32,8 +32,8 @@ electronize build /target linux
 echo "/target osx (dev-build)"
 electronize build /target osx
 
-echo "/target custom win7-x86;win32 (dev-build)"
-electronize build /target custom "win7-x86;win32"
+echo "/target custom win7-x86;win (dev-build)"
+electronize build /target custom "win7-x86;win"
 
 # Be aware, that for non-electronnet-dev environments the correct 
 # invoke command would be dotnet electronize ...


### PR DESCRIPTION
This is followup to c91884a5203c8f1f14c7320595126b1bbe60f68e change which on itself was reaction to electron-builder changes in the command line parameters interface

Close #320 