### PR TITLE
Change test application initialization procedure.

### DIFF
--- a/ElectronNET.WebApp/Program.cs
+++ b/ElectronNET.WebApp/Program.cs
@@ -8,15 +8,14 @@ namespace ElectronNET.WebApp
     {
         public static void Main(string[] args)
         {
-            BuildWebHost(args).Run();
+            CreateWebHostBuilder(args).Build().Run();
         }
 
-        public static IWebHost BuildWebHost(string[] args)
+        public static IWebHostBuilder CreateWebHostBuilder(string[] args)
         {
             return WebHost.CreateDefaultBuilder(args)
                 .UseElectron(args)
-                .UseStartup<Startup>()
-                .Build();
+                .UseStartup<Startup>();
         }
     }
 }


### PR DESCRIPTION
It essentially the same as before, but MVC test tooling expect Program to have CreateWebHostBuilder. I referer to ability to seamlessly use WebApplicationFactory
I understand that story for testing Electron application will be not easy as it is, but this is allow better defaults for testing web applications which can be run in hybrid mode.