### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,11 @@ public static IWebHost BuildWebHost(string[] args)
 Open the Electron Window in the Startup.cs file: 
 
 ```csharp
+public void ConfigureServices(IServiceCollection services)
+{            
+    services.AddMvc(option => option.EnableEndpointRouting = false);
+}
+
 public void Configure(IApplicationBuilder app, IHostingEnvironment env)
 {
     if (env.IsDevelopment())


### PR DESCRIPTION
EnableEndpointRouting should be set to false because there are breaking changes in ASP.NET Core 3.0. Otherwise people will get error: 
> 
Application startup exception: System.InvalidOperationException: Endpoint Routing does not support 'IApplicationBuilder.UseMvc(...)'. To use 'IApplicationBuilder.UseMvc' set 'MvcOptions.EnableEndpointRouting = false' inside 'ConfigureServices(...)
...
> 

The solution is even proposed in stack trace.
Issue was opened on https://github.com/aspnet/AspNetCore/issues/9542 and it is explained there what should be done.