### PR TITLE
Converted global npm dependencies to use npx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,5 @@ dist: xenial
 dotnet: 3.0
 before_script:
   - export PATH="$PATH:/home/travis/.dotnet/tools"
-  - npm install electron-packager --global
 script:
   - ./buildAll.sh

--- a/ElectronNET.CLI/Commands/AddCommand.cs
+++ b/ElectronNET.CLI/Commands/AddCommand.cs
@@ -72,9 +72,8 @@ namespace ElectronNET.CLI.Commands
                 ProcessHelper.CmdExecute("npm install", targetFilePath);
 
                 // run typescript compiler
-                string tscPath = Path.Combine(targetFilePath, "node_modules", ".bin");
                 // ToDo: Not sure if this runs under linux/macos
-                ProcessHelper.CmdExecute(@"tsc -p ../../", tscPath);
+                ProcessHelper.CmdExecute(@"npx tsc -p ../../", targetFilePath);
 
                 // search .csproj
                 Console.WriteLine($"Search your .csproj to add configure CopyToPublishDirectory to 'Never'");

--- a/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -118,7 +118,7 @@ namespace ElectronNET.CLI.Commands
                     ProcessHelper.CmdExecute("npm install", hosthookDir);
 
                     // ToDo: Not sure if this runs under linux/macos
-                    ProcessHelper.CmdExecute(@"tsc -p . --sourceMap false", hosthookDir);
+                    ProcessHelper.CmdExecute(@"npx tsc -p . --sourceMap false", hosthookDir);
                 }
 
                 Console.WriteLine("Build Electron Desktop Application...");
@@ -153,7 +153,7 @@ namespace ElectronNET.CLI.Commands
                 ProcessHelper.CmdExecute($"node build-helper.js", tempPath);
 
                 Console.WriteLine($"Package Electron App for Platform {platformInfo.ElectronPackerPlatform}...");
-                ProcessHelper.CmdExecute($"electron-builder . --config=./bin/electron-builder.json --{platformInfo.ElectronPackerPlatform} --{electronArch} -c.electronVersion=5.0.8 {electronParams}", tempPath);
+                ProcessHelper.CmdExecute($"npx electron-builder . --config=./bin/electron-builder.json --{platformInfo.ElectronPackerPlatform} --{electronArch} -c.electronVersion=5.0.8 {electronParams}", tempPath);
 
                 Console.WriteLine("... done");
 

--- a/ElectronNET.CLI/Commands/StartElectronCommand.cs
+++ b/ElectronNET.CLI/Commands/StartElectronCommand.cs
@@ -79,9 +79,8 @@ namespace ElectronNET.CLI.Commands
                     Console.WriteLine("Start npm install for typescript & hosthooks...");
                     ProcessHelper.CmdExecute("npm install", hosthookDir);
 
-                    string tscPath = Path.Combine(tempPath, "node_modules", ".bin");
                     // ToDo: Not sure if this runs under linux/macos
-                    ProcessHelper.CmdExecute(@"tsc -p ../../ElectronHostHook", tscPath);
+                    ProcessHelper.CmdExecute(@"npx tsc -p ../../ElectronHostHook", tempPath);
                 }
 
                 string path = Path.Combine(tempPath, "node_modules", ".bin");

--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ The current Electron.NET CLI builds Windows/macOS/Linux binaries. Our API uses .
 Also you should have installed:
 
 * npm 
-* npm install -g typescript
-* npm install -g electron-builder
 
 # Community
 
@@ -102,12 +100,6 @@ To start the application make sure you have installed the "[ElectronNET.CLI](htt
 
 ```
 dotnet tool install ElectronNET.CLI -g
-```
-
-* Make sure you have __node.js v8.6.0__ and on __macOS/Linux__ the electron-builder installed! 
-
-```
-sudo npm install electron-builder --global
 ```
 
 At the first time, you need an Electron.NET project initialization. Type the following command in your ASP.NET Core folder:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,6 @@
 version: 1.0.{build}
 image: Visual Studio 2019
 build_script:
-- cmd: npm install typescript --global
-- cmd: npm install electron-builder --global
 - cmd: buildAll.cmd
 pull_requests:
   do_not_increment_build_number: true


### PR DESCRIPTION
These changes remove the need to either A) install tools globally (`typescript` and `electron-builder`) and B) call tools locally via actual path (some `tsc` calls find the bin path first).

This should avoid any differences between platforms but I haven't been able to test it on every platform (just Windows for now). I should be able to run some tests on Linux this weekend.

See [my comment](https://github.com/ElectronNET/Electron.NET/pull/313#issuecomment-545256352) on #313 for more details.