### PR TITLE
Handle missing `/target` argument for `build` command.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Not released
 
+ElectronNET.CLI
+
+* Fixed a bug where `electronize build` with no arguments would throw a `KeyNotFoundException`. 
+
 # Released
 
 # 5.30.1

--- a/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -50,6 +50,13 @@ namespace ElectronNET.CLI.Commands
                 SimpleCommandLineParser parser = new SimpleCommandLineParser();
                 parser.Parse(_args);
 
+                if (!parser.Arguments.ContainsKey(_paramTarget))
+                {
+                    Console.WriteLine($"Error: missing '{_paramTarget}' argument.");
+                    Console.WriteLine(COMMAND_ARGUMENTS);
+                    return false;
+                }
+
                 var desiredPlatform = parser.Arguments[_paramTarget][0];
                 string specifiedFromCustom = string.Empty;
                 if (desiredPlatform == "custom" && parser.Arguments[_paramTarget].Length > 1)


### PR DESCRIPTION
Ran into this myself today, if a user fails to provide the `/target` argument when running `electronize build` they simply get a `KeyNotFoundException`.

This change checks for the presence of this argument and, if not present, displays help information to the user as well as gracefully exiting.

Related to https://github.com/ElectronNET/Electron.NET/issues/296

As a sidenote, is there a reason we don't use a command line parsing library (for example - https://github.com/commandlineparser/commandline) to handle these cases for us? 