### PR TITLE
Add missing config parameter fixes #407

### DIFF
--- a/ElectronNET.API/NativeTheme.cs
+++ b/ElectronNET.API/NativeTheme.cs
@@ -89,7 +89,7 @@ namespace ElectronNET.API
         /// </list>
         /// Your application should then always use <see cref="ShouldUseDarkColorsAsync"/> to determine what CSS to apply.
         /// </summary>
-        /// <param name="themeSource">The new ThemeSource.</param>
+        /// <param name="themeSourceMode">The new ThemeSource.</param>
         public void SetThemeSource(ThemeSourceMode themeSourceMode)
         {
             var themeSource = themeSourceMode.GetDescription();

--- a/ElectronNET.CLI/Commands/StartElectronCommand.cs
+++ b/ElectronNET.CLI/Commands/StartElectronCommand.cs
@@ -27,6 +27,7 @@ namespace ElectronNET.CLI.Commands
         private string _manifest = "manifest";
         private string _clearCache = "clear-cache";
         private string _paramPublishReadyToRun = "PublishReadyToRun";
+        private string _paramDotNetConfig = "dotnet-configuration";
 
         public Task<bool> ExecuteAsync()
         {
@@ -73,9 +74,15 @@ namespace ElectronNET.CLI.Commands
                     publishReadyToRun += "true";
                 }
 
+                string configuration = "Release";
+                if (parser.Arguments.ContainsKey(_paramDotNetConfig))
+                {
+                    configuration = parser.Arguments[_paramDotNetConfig][0];
+                }
+
                 if (parser != null && !parser.Arguments.ContainsKey("watch"))
                 {
-                    resultCode = ProcessHelper.CmdExecute($"dotnet publish -r {platformInfo.NetCorePublishRid} --output \"{tempBinPath}\" {publishReadyToRun} --no-self-contained", aspCoreProjectPath);
+                    resultCode = ProcessHelper.CmdExecute($"dotnet publish -r {platformInfo.NetCorePublishRid} -c {configuration} --output \"{tempBinPath}\" {publishReadyToRun} --no-self-contained", aspCoreProjectPath);
                 }
 
                 if (resultCode != 0)

--- a/ElectronNET.CLI/Properties/launchSettings.json
+++ b/ElectronNET.CLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ElectronNET.CLI": {
       "commandName": "Project",
-      "commandLineArgs": "start /project-path \"C:\\Users\\Rizvi\\source\\repos\\Electron.NET\\ElectronNET.WebApp\" /watch"
+      "commandLineArgs": "start /project-path \"$(SolutionDir)\\ElectronNET.WebApp\" /watch"
     }
   }
 }


### PR DESCRIPTION
ElectronNET.API:
- Fixed a typo in a NativeTheme summary.

ElectronNET.CLI
- Fixed bug: Custom user path removed and replaced by the correct directory with VS macro
- New Feature: Set configuration profile [Default Release] #407 
`electronize start /dotnet-configuration Release'

When ElectronNET.CLI is the Startup Project, press F5 (Debzg) and the ElectronNET.WebApp starts correctly without error!

