### PR TITLE
Added missing properties in Notifications

### DIFF
--- a/ElectronNET.API/Entities/NotificationOptions.cs
+++ b/ElectronNET.API/Entities/NotificationOptions.cs
@@ -10,28 +10,28 @@ namespace ElectronNET.API.Entities
     {
         /// <summary>
         /// A title for the notification, which will be shown at the top of the notification
-        /// window when it is shown
+        /// window when it is shown.
         /// </summary>
         public string Title { get; set; }
 
         /// <summary>
+        /// A subtitle for the notification, which will be displayed below the title.
+        /// </summary>
+        public string SubTitle { get; set; }
+
+        /// <summary>
         /// The body text of the notification, which will be displayed below the title or
-        /// subtitle
+        /// subtitle.
         /// </summary>
         public string Body { get; set; }
 
         /// <summary>
-        /// A subtitle for the notification, which will be displayed below the title.
-        /// </summary>
-        public string Subtitle { get; set; }
-
-        /// <summary>
-        /// Whether or not to emit an OS notification noise when showing the notification
+        /// Whether or not to emit an OS notification noise when showing the notification.
         /// </summary>
         public bool Silent { get; set; }
 
         /// <summary>
-        /// An icon to use in the notification
+        /// An icon to use in the notification.
         /// </summary>
         public string Icon { get; set; }
 
@@ -39,6 +39,11 @@ namespace ElectronNET.API.Entities
         /// Whether or not to add an inline reply option to the notification.
         /// </summary>
         public bool HasReply { get; set; }
+
+        /// <summary>
+        /// The timeout duration of the notification. Can be 'default' or 'never'.
+        /// </summary>
+        public string TimeoutType { get; set; }
 
         /// <summary>
         /// The placeholder to write in the inline reply input field.
@@ -51,15 +56,26 @@ namespace ElectronNET.API.Entities
         public string Sound { get; set; }
 
         /// <summary>
+        /// The urgency level of the notification. Can be 'normal', 'critical', or 'low'.
+        /// </summary>
+        public string Urgency { get; set; }
+
+        /// <summary>
         /// Actions to add to the notification. Please read the available actions and
-        /// limitations in the NotificationAction documentation
+        /// limitations in the NotificationAction documentation.
         /// </summary>
         public NotificationAction Actions { get; set; }
 
         /// <summary>
-        /// Emitted when the notification is shown to the user, 
-        /// note this could be fired multiple times as a notification 
-        /// can be shown multiple times through the Show() method.
+        /// A custom title for the close button of an alert. An empty string will cause the
+        /// default localized text to be used.
+        /// </summary>
+        public string CloseButtonText { get; set; }
+
+        /// <summary>
+        /// Emitted when the notification is shown to the user, note this could be fired
+        /// multiple times as a notification can be shown multiple times through the Show()
+        /// method.
         /// </summary>
         [JsonIgnore]
         public Action OnShow { get; set; }


### PR DESCRIPTION
Good news, all properties, methods of notifications are now included. The bad news is, the property that should fixed #408 cannot be used at the moment because the implementation in electron is [bugged](https://github.com/electron/electron/issues/22192).