### PR TITLE
New App.IsReady property

### DIFF
--- a/ElectronNET.API/App.cs
+++ b/ElectronNET.API/App.cs
@@ -6,6 +6,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
 
 namespace ElectronNET.API
 {
@@ -351,6 +352,11 @@ namespace ElectronNET.API
         }
 
         private event Action<bool> _accessibilitySupportChanged;
+
+        /// <summary>
+        /// Application host fully started.
+        /// </summary>
+        public bool IsReady { get; internal set; }
 
         /// <summary>
         /// A property that indicates the current application's name, which is the

--- a/ElectronNET.API/LifetimeServiceHost.cs
+++ b/ElectronNET.API/LifetimeServiceHost.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+namespace ElectronNET.API
+{
+    /// <summary>
+    /// Base class that reports if ASP.NET Core has fully started.
+    /// </summary>
+    internal class LifetimeServiceHost : IHostedService
+    {
+        public LifetimeServiceHost(IHostApplicationLifetime lifetime)
+        {
+            lifetime.ApplicationStarted.Register(() =>
+            {
+                App.Instance.IsReady = true;
+
+                Console.WriteLine("ASP.NET Core host has fully started.");
+            });
+        }
+
+        /// <summary>
+        /// Triggered when the application host is ready to start the service.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the start process has been aborted.</param>
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// Triggered when the application host is performing a graceful shutdown.
+        /// </summary>
+        /// <param name="cancellationToken">Indicates that the shutdown process should no longer be graceful.</param>
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/ElectronNET.API/WebHostBuilderExtensions.cs
+++ b/ElectronNET.API/WebHostBuilderExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.Hosting;
 using System;
 using System.IO;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace ElectronNET.API
 {
@@ -32,6 +33,11 @@ namespace ElectronNET.API
 
             if (HybridSupport.IsElectronActive)
             {
+                builder.ConfigureServices(services =>
+                {
+                    services.AddHostedService<LifetimeServiceHost>();
+                });
+
                 // check for the content folder if its exists in base director otherwise no need to include
                 // It was used before because we are publishing the project which copies everything to bin folder and contentroot wwwroot was folder there.
                 // now we have implemented the live reload if app is run using /watch then we need to use the default project path.

--- a/ElectronNET.CLI/Properties/launchSettings.json
+++ b/ElectronNET.CLI/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "ElectronNET.CLI": {
       "commandName": "Project",
-      "commandLineArgs": "start /project-path \"$(SolutionDir)\\ElectronNET.WebApp\" /watch"
+      "commandLineArgs": "start /project-path \"$(SolutionDir)ElectronNET.WebApp\" /watch"
     }
   }
 }

--- a/ElectronNET.WebApp/Controllers/MenusController.cs
+++ b/ElectronNET.WebApp/Controllers/MenusController.cs
@@ -2,27 +2,20 @@
 using Microsoft.AspNetCore.Mvc;
 using ElectronNET.API.Entities;
 using ElectronNET.API;
-using Microsoft.Extensions.Hosting;
 
 namespace ElectronNET.WebApp.Controllers
 {
     public class MenusController : Controller
     {
-        public MenusController(IHostApplicationLifetime hostApplicationLifetime)
-        {
-            hostApplicationLifetime.ApplicationStarted.Register(() =>
-            {
-                if (HybridSupport.IsElectronActive)
-                {
-                    CreateContextMenu();
-                }
-            });
-        }
-
         public IActionResult Index()
         {
             if (HybridSupport.IsElectronActive)
             {
+                if (Electron.App.IsReady)
+                {
+                    CreateContextMenu();
+                }
+
                 var menu = new MenuItem[] {
                 new MenuItem { Label = "Edit", Submenu = new MenuItem[] {
                     new MenuItem { Label = "Undo", Accelerator = "CmdOrCtrl+Z", Role = MenuRole.undo },

--- a/ElectronNET.WebApp/Startup.cs
+++ b/ElectronNET.WebApp/Startup.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Hosting;
 
 namespace ElectronNET.WebApp


### PR DESCRIPTION
The new property indicates when the ASP.NET Core host is fully started. The validation is done directly in the API so that the user does not have to do this himself. See before and after MenuController  [example](https://github.com/ElectronNET/Electron.NET/commit/52b850092ce99eda56b45f41bcb63a9b542f2004).