### PR TITLE
Enabled empty tray icon

### DIFF
--- a/ElectronNET.API/Tray.cs
+++ b/ElectronNET.API/Tray.cs
@@ -264,6 +264,15 @@ namespace ElectronNET.API
         }
 
         /// <summary>
+        /// Shows the Traybar (empty).
+        /// </summary>
+        /// <param name="image">The image.</param>
+        public void Show(string image)
+        {
+            BridgeConnector.Socket.Emit("create-tray", image);
+        }
+
+        /// <summary>
         /// Destroys the tray icon immediately.
         /// </summary>
         public void Destroy()

--- a/ElectronNET.Host/api/tray.js
+++ b/ElectronNET.Host/api/tray.js
@@ -47,13 +47,17 @@ module.exports = (socket) => {
         }
     });
     socket.on('create-tray', (image, menuItems) => {
-        const menu = electron_1.Menu.buildFromTemplate(menuItems);
-        addMenuItemClickConnector(menu.items, (id) => {
-            electronSocket.emit('trayMenuItemClicked', id);
-        });
         const trayIcon = electron_1.nativeImage.createFromPath(image);
         tray = new electron_1.Tray(trayIcon);
-        tray.setContextMenu(menu);
+
+        if (menuItems) {
+            const menu = electron_1.Menu.buildFromTemplate(menuItems);
+            addMenuItemClickConnector(menu.items, (id) => {
+                electronSocket.emit('trayMenuItemClicked', id);
+            });
+
+            tray.setContextMenu(menu);
+        }
     });
     socket.on('tray-destroy', () => {
         if (tray) {

--- a/ElectronNET.Host/api/tray.ts
+++ b/ElectronNET.Host/api/tray.ts
@@ -53,16 +53,18 @@ export = (socket: SocketIO.Socket) => {
     });
 
     socket.on('create-tray', (image, menuItems) => {
-        const menu = Menu.buildFromTemplate(menuItems);
-
-        addMenuItemClickConnector(menu.items, (id) => {
-            electronSocket.emit('trayMenuItemClicked', id);
-        });
-
         const trayIcon = nativeImage.createFromPath(image);
 
         tray = new Tray(trayIcon);
-        tray.setContextMenu(menu);
+
+        if (menuItems) {
+            const menu = Menu.buildFromTemplate(menuItems);
+    
+            addMenuItemClickConnector(menu.items, (id) => {
+                electronSocket.emit('trayMenuItemClicked', id);
+            });
+            tray.setContextMenu(menu);
+        }
     });
 
     socket.on('tray-destroy', () => {


### PR DESCRIPTION
This allows empty tray icon to be placed without a context menu. Useful for cases when only minimize/close to tray is implemented.

This somehow also fixes menu icon click events in macOS. (probably a thing in base electronjs as well). Not sure about other OS though.