### PR TITLE
Update Documentation in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,9 @@ MIT-licensed
 
 ## 📝 Important notes
 
-### ElectronNET.API & ElectronNET.CLI Version 8.31.1
+### ElectronNET.API & ElectronNET.CLI Version 9.31.2
 
-Make sure you also have the new Electron.NET API & CLI 8.31.1 version.
+Make sure you also have the new Electron.NET API & CLI 9.31.2 version.
 
 ```
 dotnet tool update ElectronNET.CLI -g


### PR DESCRIPTION
The README.md file still referenced the old 8.31.1 version of the ElectronNET.CLI.
This is just a documentation change for clarity.  

This PR updates the README.md to reference the lastest tooling as of Monday, July 6, 2020, at 19:06:12 UTC.

**Old Version**
![image](https://user-images.githubusercontent.com/31376573/86630096-3d65f580-bf81-11ea-8aaa-f4134b953346.png)

**New Version**
![image](https://user-images.githubusercontent.com/31376573/86630184-58d10080-bf81-11ea-8baa-f8f81005f19c.png)
