### PR TITLE
Add target command line option found in 'build' to 'start' in CLI to …

### DIFF
--- a/ElectronNET.CLI/Commands/StartElectronCommand.cs
+++ b/ElectronNET.CLI/Commands/StartElectronCommand.cs
@@ -28,6 +28,7 @@ namespace ElectronNET.CLI.Commands
         private string _clearCache = "clear-cache";
         private string _paramPublishReadyToRun = "PublishReadyToRun";
         private string _paramDotNetConfig = "dotnet-configuration";
+        private string _paramTarget = "target";
 
         public Task<bool> ExecuteAsync()
         {
@@ -59,8 +60,6 @@ namespace ElectronNET.CLI.Commands
                     Directory.CreateDirectory(tempPath);
                 }
 
-                var platformInfo = GetTargetPlatformInformation.Do(string.Empty, string.Empty);
-
                 string tempBinPath = Path.Combine(tempPath, "bin");
                 var resultCode = 0;
 
@@ -72,6 +71,21 @@ namespace ElectronNET.CLI.Commands
                 else
                 {
                     publishReadyToRun += "true";
+                }
+
+                // If target is specified as a command line argument, use it.
+                // Format is the same as the build command. 
+                // If target is not specified, autodetect it.
+                var platformInfo = GetTargetPlatformInformation.Do(string.Empty, string.Empty);
+                if (parser.Arguments.ContainsKey(_paramTarget))
+                {
+                    var desiredPlatform = parser.Arguments[_paramTarget][0];
+                    string specifiedFromCustom = string.Empty;
+                    if (desiredPlatform == "custom" && parser.Arguments[_paramTarget].Length > 1)
+                    {
+                        specifiedFromCustom = parser.Arguments[_paramTarget][1];
+                    }
+                    platformInfo = GetTargetPlatformInformation.Do(desiredPlatform, specifiedFromCustom);
                 }
 
                 string configuration = "Debug";


### PR DESCRIPTION
…support custom targets in development.

Hello! 

Thank you for all of your work on Electron.NET. 

I added the ability to specify the platform target to the start subcommand in the CLI. I needed this because my application is dependent on several x86 C APIs and it will not build in x64, even in debug. 

For reference, the application is Blazor server side.