### PR TITLE
set default WebPreferences.DefaultFontSize

### DIFF
--- a/ElectronNET.API/Entities/WebPreferences.cs
+++ b/ElectronNET.API/Entities/WebPreferences.cs
@@ -142,7 +142,7 @@ namespace ElectronNET.API.Entities
         /// <summary>
         /// Defaults to 16.
         /// </summary>
-        public int DefaultFontSize { get; set; }
+        public int DefaultFontSize { get; set; } = 16;
 
         /// <summary>
         /// Defaults to 13.


### PR DESCRIPTION
Fix regression of #345 where the default font size is overridden when the window position is set on creation.