### PR TITLE
Added support for launching the application with a file on MacOS

### DIFF
--- a/ElectronNET.API/App.cs
+++ b/ElectronNET.API/App.cs
@@ -399,6 +399,70 @@ namespace ElectronNET.API
         private bool _isReady = false;
 
         /// <summary>
+        /// Emitted when a MacOS user wants to open a file with the application. The open-file event is usually emitted
+        /// when the application is already open and the OS wants to reuse the application to open the file.
+        /// open-file is also emitted when a file is dropped onto the dock and the application is not yet running.
+        /// <para/>
+        /// On Windows, you have to parse the arguments using App.CommandLine to get the filepath.
+        /// </summary>
+        public event Action<string> OpenFile
+        {
+            add
+            {
+                if (_openFile == null)
+                {
+                    BridgeConnector.Socket.On("app-open-file" + GetHashCode(), (file) =>
+                    {
+                        _openFile(file.ToString());
+                    });
+
+                    BridgeConnector.Socket.Emit("register-app-open-file-event", GetHashCode());
+                }
+                _openFile += value;
+            }
+            remove
+            {
+                _openFile -= value;
+
+                if (_openFile == null)
+                    BridgeConnector.Socket.Off("app-open-file" + GetHashCode());
+            }
+        }
+
+        private event Action<string> _openFile;
+
+
+        /// <summary>
+        /// Emitted when a MacOS user wants to open a URL with the application. Your application's Info.plist file must
+        /// define the URL scheme within the CFBundleURLTypes key, and set NSPrincipalClass to AtomApplication.
+        /// </summary>
+        public event Action<string> OpenUrl
+        {
+            add
+            {
+                if (_openUrl == null)
+                {
+                    BridgeConnector.Socket.On("app-open-url" + GetHashCode(), (url) =>
+                    {
+                        _openUrl(url.ToString());
+                    });
+
+                    BridgeConnector.Socket.Emit("register-app-open-url-event", GetHashCode());
+                }
+                _openUrl += value;
+            }
+            remove
+            {
+                _openUrl -= value;
+
+                if (_openUrl == null)
+                    BridgeConnector.Socket.Off("app-open-url" + GetHashCode());
+            }
+        }
+
+        private event Action<string> _openUrl;
+
+        /// <summary>
         /// A <see cref="string"/> property that indicates the current application's name, which is the name in the
         /// application's package.json file.
         ///

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -17,7 +17,7 @@ echo "Restore & Build CLI"
 pushd $dir/ElectronNET.CLI
     dotnet restore
     dotnet build
-podp
+popd
 
 echo "Restore & Build WebApp Demo"
 pushd $dir/ElectronNET.WebApp


### PR DESCRIPTION
Added support for launching the application with a file on MacOS by listening for the open-file and open-url events from the operating system, and forwarding them to the Electron.NET app when listeners are added