### PR TITLE
Upgrade to .NET 5

### DIFF
--- a/ElectronNET.API/ElectronNET.API.csproj
+++ b/ElectronNET.API/ElectronNET.API.csproj
@@ -36,12 +36,12 @@ This package contains the API to access the "native" electron API.</Description>
    <FrameworkReference Include="Microsoft.AspNetCore.App" />
 </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SocketIoClientDotNet" Version="1.0.5" />
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ElectronNET.API/ElectronNET.API.csproj
+++ b/ElectronNET.API/ElectronNET.API.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>..\artifacts</PackageOutputPath>
     <PackageId>ElectronNET.API</PackageId>

--- a/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -77,7 +77,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>dotnet-electronize</AssemblyName>
     <ToolCommandName>electronize</ToolCommandName>
 

--- a/ElectronNET.WebApp/ElectronNET.WebApp.csproj
+++ b/ElectronNET.WebApp/ElectronNET.WebApp.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>

--- a/ElectronNET.WebApp/ElectronNET.WebApp.csproj
+++ b/ElectronNET.WebApp/ElectronNET.WebApp.csproj
@@ -4,7 +4,7 @@
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
-    <TypeScriptToolsVersion>3.8</TypeScriptToolsVersion>
+    <TypeScriptToolsVersion>4.0</TypeScriptToolsVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Controllers\ManageWindowsController.cs" />

--- a/ElectronNET.WebApp/ElectronNET.WebApp.csproj
+++ b/ElectronNET.WebApp/ElectronNET.WebApp.csproj
@@ -16,7 +16,7 @@
     <Folder Include="wwwroot\assets\" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ElectronNET.API\ElectronNET.API.csproj" />


### PR DESCRIPTION
Upgraded projects from .NET 3.1 to .NET 5.0.

Upgraded WebApp project from TypeScript 3.8 to TypeScript 5.0.

Upgraded NuGet packages to the latest versions:
- Microsoft.SourceLink.GitHub 1.0.0-beta2-19367-01 > 1.0.0
- System.Drawing.Common 4.7.0 > 5.0.0
- Microsoft.VisualStudio.Web.CodeGeneration.Design 3.0.0 > 5.0.0

This addresses issue #491 