### PR TITLE
Resolve #539, #357 - Fix splash screen interaction causing crashes, ghost dragging, and resizable behavior

### DIFF
--- a/ElectronNET.Host/main.js
+++ b/ElectronNET.Host/main.js
@@ -123,6 +123,7 @@ function startSplashScreen() {
             closable: false,
             resizable: false,
             skipTaskbar: true,
+            alwaysOnTop: true,
             show: true
         });
         splashScreen.setIgnoreMouseEvents(true);

--- a/ElectronNET.Host/main.js
+++ b/ElectronNET.Host/main.js
@@ -121,14 +121,13 @@ function startSplashScreen() {
             center: true,
             frame: false,
             closable: false,
+            resizable: false,
             skipTaskbar: true,
             show: true
         });
 
-        app.once('browser-window-focus', () => {
-            app.once('browser-window-focus', () => {
-                splashScreen.destroy();
-            });
+        app.once('browser-window-created', () => {
+            splashScreen.destroy();
         });
 
         const loadSplashscreenUrl = path.join(__dirname, 'splashscreen', 'index.html') + '?imgPath=' + imageFile;

--- a/ElectronNET.Host/main.js
+++ b/ElectronNET.Host/main.js
@@ -125,6 +125,7 @@ function startSplashScreen() {
             skipTaskbar: true,
             show: true
         });
+        splashScreen.setIgnoreMouseEvents(true);
 
         app.once('browser-window-created', () => {
             splashScreen.destroy();

--- a/ElectronNET.Host/splashscreen/index.html
+++ b/ElectronNET.Host/splashscreen/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html lang="en">
 
 <head>
@@ -15,7 +15,7 @@
       }
    </style>
 
-   <img alt="splashscreen" style="width: 100%; height: 100%;">
+   <img draggable="false" alt="splashscreen" style="width: 100%; height: 100%;">
 
    <script>
       (() => {


### PR DESCRIPTION
Resolves #539, #357

Using the `browser-window-focus` event would cause the splashScreen window to be destroyed early (since regular mouse-focus events would cause the event to be fired).

Switching to the `browser-window-created` event produces the correct behavior.