### PR TITLE
Add PostData to LoadURLOptions to allow http-posts in LoadURL calls

### DIFF
--- a/ElectronNET.API/Entities/Blob.cs
+++ b/ElectronNET.API/Entities/Blob.cs
@@ -1,0 +1,18 @@
+﻿namespace ElectronNET.API.Entities
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class Blob : IPostData
+    {
+        /// <summary>
+        /// The object represents a Blob
+        /// </summary>
+        public string Type { get; } = "blob";
+
+        /// <summary>
+        /// The UUID of the Blob being uploaded
+        /// </summary>
+        public string BlobUUID { get; set; }
+    }
+}

--- a/ElectronNET.API/Entities/IPostData.cs
+++ b/ElectronNET.API/Entities/IPostData.cs
@@ -1,0 +1,16 @@
+﻿namespace ElectronNET.API.Entities
+{
+    /// <summary>
+    /// Interface to use Electrons PostData Object
+    /// </summary>
+    public interface IPostData
+    {
+        /// <summary>
+        /// One of the following:
+        /// rawData - <see cref="UploadRawData"/> The data is available as a Buffer, in the rawData field.
+        /// file - <see cref="UploadFile"/> The object represents a file. The filePath, offset, length and modificationTime fields will be used to describe the file.
+        /// blob - <see cref="Blob"/> The object represents a Blob. The blobUUID field will be used to describe the Blob.
+        /// </summary>
+        public string Type { get; }
+    }
+}

--- a/ElectronNET.API/Entities/LoadURLOptions.cs
+++ b/ElectronNET.API/Entities/LoadURLOptions.cs
@@ -26,5 +26,11 @@
         /// Extra headers for the request.
         /// </summary>
         public string ExtraHeaders { get; set; }
+
+        /// <summary>
+        /// PostData Object for the request.
+        /// Can be <see cref="UploadRawData"/>, <see cref="UploadFile"/> or <see cref="Blob"/>
+        /// </summary>
+        public IPostData[] PostData { get; set; }
     }
 }

--- a/ElectronNET.API/Entities/UploadFile.cs
+++ b/ElectronNET.API/Entities/UploadFile.cs
@@ -1,0 +1,34 @@
+﻿namespace ElectronNET.API.Entities
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class UploadFile : IPostData
+    {
+        /// <summary>
+        /// The object represents a file.
+        /// </summary>
+        public string Type { get; } = "file";
+
+        /// <summary>
+        /// The path of the file being uploaded.
+        /// </summary>
+        public string FilePath { get; set; }
+
+        /// <summary>
+        /// The offset from the beginning of the file being uploaded, in bytes. Defaults to 0.
+        /// </summary>
+        public long Offset { get; set; } = 0;
+
+        /// <summary>
+        /// The length of the file being uploaded, <see cref="Offset"/>. Defaults to 0.
+        /// If set to -1, the whole file will be uploaded.
+        /// </summary>
+        public long Length { get; set; } = 0;
+
+        /// <summary>
+        /// The modification time of the file represented by a double, which is the number of seconds since the UNIX Epoch (Jan 1, 1970)
+        /// </summary>
+        public double ModificationTime { get; set; }
+    }
+}

--- a/ElectronNET.API/Entities/UploadRawData.cs
+++ b/ElectronNET.API/Entities/UploadRawData.cs
@@ -1,0 +1,18 @@
+﻿namespace ElectronNET.API.Entities
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class UploadRawData : IPostData
+    {
+        /// <summary>
+        /// The data is available as a Buffer, in the rawData field.
+        /// </summary>
+        public string Type { get; } = "rawData";
+        
+        /// <summary>
+        /// The raw bytes of the post data in a Buffer.
+        /// </summary>
+        public byte[] Bytes { get; set; }
+    }
+}


### PR DESCRIPTION
Enable the possibility to post data to external Url's with the BrowserWindow.LoadURL function. The post data is provided through LoadURLOptions