### PR TITLE
Using exit code instead of seek for the term 'error'

### DIFF
--- a/ElectronNET.CLI/ProcessHelper.cs
+++ b/ElectronNET.CLI/ProcessHelper.cs
@@ -1,14 +1,11 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
-using System.Text.RegularExpressions;
 
 namespace ElectronNET.CLI
 {
     public class ProcessHelper
     {
-        private readonly static Regex ErrorRegex = new Regex(@"\berror\b", RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
         public static int CmdExecute(string command, string workingDirectoryPath, bool output = true, bool waitForExit = true)
         {
             using (Process cmd = new Process())
@@ -17,12 +14,12 @@ namespace ElectronNET.CLI
 
                 if (isWindows)
                 {
-                    cmd.StartInfo.FileName = "cmd.exe";
+                    cmd.StartInfo = new ProcessStartInfo("cmd.exe", "/c " + command);
                 }
                 else
                 {
                     // works for OSX and Linux (at least on Ubuntu)
-                    cmd.StartInfo.FileName = "bash";
+                    cmd.StartInfo = new ProcessStartInfo("bash", "-c " + command);
                 }
 
                 cmd.StartInfo.RedirectStandardInput = true;
@@ -32,65 +29,22 @@ namespace ElectronNET.CLI
                 cmd.StartInfo.UseShellExecute = false;
                 cmd.StartInfo.WorkingDirectory = workingDirectoryPath;
 
-                int returnCode = 0;
-
                 if (output)
                 {
-                    cmd.OutputDataReceived += (s, e) =>
-                    {
-                        // (sometimes error messages are only visbile here)
-                        // poor mans solution, we just seek for the term 'error'
-
-                        // we can't just use cmd.ExitCode, because
-                        // we delegate it to cmd.exe, which runs fine
-                        // but we can catch any error here and return
-                        // 1 if something fails
-                        if (e != null && string.IsNullOrWhiteSpace(e.Data) == false)
-                        {
-                            if (ErrorRegex.IsMatch(e.Data))
-                            {
-                                returnCode = 1;
-                            }
-
-                            Console.WriteLine(e.Data);
-                        }
-
-                    };
-                    cmd.ErrorDataReceived += (s, e) =>
-                    {
-                        // poor mans solution, we just seek for the term 'error'
-
-                        // we can't just use cmd.ExitCode, because
-                        // we delegate it to cmd.exe, which runs fine
-                        // but we can catch any error here and return
-                        // 1 if something fails
-                        if (e != null && string.IsNullOrWhiteSpace(e.Data) == false)
-                        {
-                            if (ErrorRegex.IsMatch(e.Data))
-                            {
-                                returnCode = 1;
-                            }
-
-                            Console.WriteLine(e.Data);
-                        }
-
-                    };
+                    cmd.OutputDataReceived += (s, e) => Console.WriteLine(e.Data);
+                    cmd.ErrorDataReceived += (s, e) => Console.WriteLine(e.Data);
                 }
 
                 cmd.Start();
                 cmd.BeginOutputReadLine();
                 cmd.BeginErrorReadLine();
 
-                cmd.StandardInput.WriteLine(command);
-                cmd.StandardInput.Flush();
-                cmd.StandardInput.Close();
-
                 if (waitForExit)
                 {
                     cmd.WaitForExit();
                 }
 
-                return returnCode;
+                return cmd.ExitCode;
             }
         }
     }

--- a/ElectronNET.CLI/ProcessHelper.cs
+++ b/ElectronNET.CLI/ProcessHelper.cs
@@ -19,7 +19,8 @@ namespace ElectronNET.CLI
                 else
                 {
                     // works for OSX and Linux (at least on Ubuntu)
-                    cmd.StartInfo = new ProcessStartInfo("bash", "-c " + command);
+                    var escapedArgs = command.Replace("\"", "\\\"");
+                    cmd.StartInfo = new ProcessStartInfo("bash", $"-c \"{escapedArgs}\"");
                 }
 
                 cmd.StartInfo.RedirectStandardInput = true;

--- a/ElectronNET.CLI/ProcessHelper.cs
+++ b/ElectronNET.CLI/ProcessHelper.cs
@@ -36,6 +36,7 @@ namespace ElectronNET.CLI
                     cmd.ErrorDataReceived += (s, e) => Console.WriteLine(e.Data);
                 }
 
+                Console.WriteLine(command);
                 cmd.Start();
                 cmd.BeginOutputReadLine();
                 cmd.BeginErrorReadLine();


### PR DESCRIPTION
Maybe I didn't take into account something, but I think it will work better.
It fixes my problem with warning in `dotnet publish` output like this:

> ...\Pages\\**Error**.cshtml.cs(13,18): warning SA1649: File name should match first type name.