### PR TITLE
Vibrancy serialization fix

### DIFF
--- a/ElectronNET.API/Entities/Vibrancy.cs
+++ b/ElectronNET.API/Entities/Vibrancy.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+﻿using System.Runtime.Serialization;
 
 namespace ElectronNET.API.Entities
 {
@@ -10,7 +10,7 @@ namespace ElectronNET.API.Entities
         /// <summary>
         /// The appearance based
         /// </summary>
-        [JsonProperty("appearance-based")]
+        [EnumMember(Value = "appearance-based")]
         appearanceBased,
 
         /// <summary>
@@ -51,13 +51,13 @@ namespace ElectronNET.API.Entities
         /// <summary>
         /// The medium light
         /// </summary>
-        [JsonProperty("medium-light")]
+        [EnumMember(Value = "medium-light")]
         mediumLight,
 
         /// <summary>
         /// The ultra dark
         /// </summary>
-        [JsonProperty("ultra-dark")]
+        [EnumMember(Value = "ultra-dark")]
         ultraDark
     }
 }


### PR DESCRIPTION
Noticed that Vibrancy serialization works incorrect. It may lead to crash on macOS if incorrectly serialized values are used. I've tested it. Application crashed.
Json property attributes are ignored because they are placed too deep. This changes will fix that.

You may read about custom enum values names serialization [here](https://automationrhapsody.com/serialize-and-deserialize-enum-values-to-custom-string-in-c-with-json-net/) (random article about it) or somewhere else.