### PR TITLE
Set PublishSingleFile default back to false for NET5 compatibility

### DIFF
--- a/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -211,7 +211,7 @@ namespace ElectronNET.CLI.Commands
             var dotNetPublishFlags = new Dictionary<string, string>
             {
                 {"/p:PublishReadyToRun", parser.TryGet(_paramPublishReadyToRun, out var rtr) ? rtr[0] : "true"},
-                {"/p:PublishSingleFile", parser.TryGet(_paramPublishSingleFile, out var psf) ? psf[0] : "true"},
+                {"/p:PublishSingleFile", parser.TryGet(_paramPublishSingleFile, out var psf) ? psf[0] : "false"},
             };
 
             if (parser.Arguments.ContainsKey(_paramVersion))


### PR DESCRIPTION
This was changed before and is also noted in the current changelog. The change was lost during the merge of [Bug 578](https://github.com/ElectronNET/Electron.NET/issues/578)