### PR TITLE
Fix IndexOutOfRangeException in build command parsing logic

### DIFF
--- a/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -61,7 +61,7 @@ namespace ElectronNET.CLI.Commands
                 if (parser.Arguments.ContainsKey(_paramVersion))
                     version = parser.Arguments[_paramVersion][0];
 
-                if (!parser.Arguments.ContainsKey(_paramTarget))
+                if (!parser.Arguments.ContainsKey(_paramTarget) || parser.Arguments[_paramTarget].Length == 0)
                 {
                     Console.WriteLine($"Error: missing '{_paramTarget}' argument.");
                     Console.WriteLine(COMMAND_ARGUMENTS);


### PR DESCRIPTION
Hi there,

Thanks for this great project so we can build electron app in C# smoothly. I just found a small issue in the build command parsing logic and commit a fix about this.

### How to reproduce the issue?

```
$ electronize build /target
Build Electron Application...
Arguments: 
        target = 
Unhandled exception. System.AggregateException: One or more errors occurred. (Index was outside the bounds of the array.)
 ---> System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at ElectronNET.CLI.Commands.BuildCommand.<ExecuteAsync>b__21_0() in C:\_WorkRepos\Electron.NET\ElectronNET.CLI\Commands\BuildCommand.cs:line 54
   at System.Threading.Tasks.Task`1.InnerInvoke()
   at System.Threading.Tasks.Task.<>c.<.cctor>b__277_0(Object obj)
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
--- End of stack trace from previous location ---
   at System.Threading.ExecutionContext.RunFromThreadPoolDispatchLoop(Thread threadPoolThread, ExecutionContext executionContext, ContextCallback callback, Object state)
   at System.Threading.Tasks.Task.ExecuteWithThreadLocal(Task& currentTaskSlot, Thread threadPoolThread)
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task`1.GetResultCore(Boolean waitCompletionNotification)
   at System.Threading.Tasks.Task`1.get_Result()
   at ElectronNET.CLI.Program.Main(String[] args) in C:\_WorkRepos\Electron.NET\ElectronNET.CLI\Program.cs:line 59
[1]    2879 abort      electronize build /target

```