### PR TITLE
Support Apple Silicon Natively

### DIFF
--- a/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
+++ b/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 
 namespace ElectronNET.CLI.Commands.Actions
@@ -30,6 +31,15 @@ namespace ElectronNET.CLI.Commands.Actions
                 case "osx-arm64":
                     netCorePublishRid = "osx-arm64";
                     electronPackerPlatform = "mac";
+
+                    //Check to see if .net 6 is installed:
+                    if (!Dotnet6Installed())
+                    {
+                        throw new ArgumentException("You are using a dotnet version older than dotnet 6. Compiling for osx-arm64 requires that dotnet 6 or greater is installed and targeted by your project.", "osx-arm64");
+                    }
+
+                    //Warn for .net 6 targeting:
+                    Console.WriteLine("Please ensure that your project targets .net 6 or greater. Otherwise you may experience an error compiling for osx-arm64.");
                     break;
                 case "linux":
                     netCorePublishRid = "linux-x64";
@@ -52,8 +62,11 @@ namespace ElectronNET.CLI.Commands.Actions
                     }
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                     {
-                        if (RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64))
+                        if (RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64) && Dotnet6Installed())
                         {
+                            //Warn for .net 6 targeting:
+                            Console.WriteLine("Please ensure that your project targets .net 6. Otherwise you may experience an error.");
+
                             //Apple Silicon Mac:
                             netCorePublishRid = "osx-arm64";
                             electronPackerPlatform = "mac";
@@ -78,6 +91,38 @@ namespace ElectronNET.CLI.Commands.Actions
                 ElectronPackerPlatform = electronPackerPlatform,
                 NetCorePublishRid = netCorePublishRid
             };
+        }
+        /// <summary>
+        /// Checks to see if dotnet 6 or greater is installed.
+        /// Required for MacOS arm targeting.
+        /// Note that an error may still occur if the project being compiled does not target dotnet 6 or greater. 
+        /// </summary>
+        /// <returns>
+        /// Returns true if dotnet 6 or greater is installed.
+        /// </returns>
+        private static bool Dotnet6Installed()
+        {
+            //check for .net 6:
+            Process process = new Process();
+            process.StartInfo.FileName = "dotnet";
+            process.StartInfo.Arguments = "--list-sdks";
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.RedirectStandardError = true;
+            process.Start();
+
+            string standard_output;
+            bool dotnet6Exists = false;
+            while ((standard_output = process.StandardOutput.ReadLine()) != null)
+            {
+                if (standard_output.StartsWith("6."))
+                {
+                    dotnet6Exists = true;
+                    break;
+                }
+            }
+            process.WaitForExit();
+            return dotnet6Exists;
         }
     }
 }

--- a/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
+++ b/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
@@ -27,6 +27,10 @@ namespace ElectronNET.CLI.Commands.Actions
                     netCorePublishRid = "osx-x64";
                     electronPackerPlatform = "mac";
                     break;
+                case "osx-arm64":
+                    netCorePublishRid = "osx-arm64";
+                    electronPackerPlatform = "darwin-arm64";
+                    break;
                 case "linux":
                     netCorePublishRid = "linux-x64";
                     electronPackerPlatform = "linux";
@@ -48,8 +52,17 @@ namespace ElectronNET.CLI.Commands.Actions
                     }
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                     {
-                        netCorePublishRid = "osx-x64";
-                        electronPackerPlatform = "mac";
+                        if (RuntimeInformation.OSArchitecture.Equals(Architecture.Arm64))
+                        {
+                            //Apple Silicon Mac:
+                            netCorePublishRid = "osx-arm64";
+                            electronPackerPlatform = "darwin-arm64";
+                        }
+                        else{
+                            //Intel Mac:
+                            netCorePublishRid = "osx-x64";
+                            electronPackerPlatform = "mac";
+                        }
                     }
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     {

--- a/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
+++ b/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
@@ -103,6 +103,7 @@ namespace ElectronNET.CLI.Commands.Actions
         private static bool Dotnet6Installed()
         {
             //check for .net 6:
+            //execute dotnet --list-sdks to get versions
             Process process = new Process();
             process.StartInfo.FileName = "dotnet";
             process.StartInfo.Arguments = "--list-sdks";
@@ -113,9 +114,13 @@ namespace ElectronNET.CLI.Commands.Actions
 
             string standard_output;
             bool dotnet6Exists = false;
+
+            //get command output:
             while ((standard_output = process.StandardOutput.ReadLine()) != null)
             {
-                if (standard_output.StartsWith("6."))
+                //get the major version and see if its greater than or equal to 6
+                int majorVer = int.Parse(standard_output.Split(".")[0]);
+                if (majorVer >= 6)
                 {
                     dotnet6Exists = true;
                     break;

--- a/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
+++ b/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
@@ -29,7 +29,7 @@ namespace ElectronNET.CLI.Commands.Actions
                     break;
                 case "osx-arm64":
                     netCorePublishRid = "osx-arm64";
-                    electronPackerPlatform = "darwin-arm64";
+                    electronPackerPlatform = "mac";
                     break;
                 case "linux":
                     netCorePublishRid = "linux-x64";
@@ -56,7 +56,7 @@ namespace ElectronNET.CLI.Commands.Actions
                         {
                             //Apple Silicon Mac:
                             netCorePublishRid = "osx-arm64";
-                            electronPackerPlatform = "darwin-arm64";
+                            electronPackerPlatform = "mac";
                         }
                         else{
                             //Intel Mac:

--- a/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -170,7 +170,13 @@ namespace ElectronNET.CLI.Commands
 
                 Console.WriteLine("Executing electron magic in this directory: " + buildPath);
 
+                
                 string electronArch = "x64";
+                //Somewhat janky fix for Apple Silicon:
+                if (platformInfo.NetCorePublishRid == "osx-arm64")
+                {
+                    electronArch = "arm64";
+                }
                 if (parser.Arguments.ContainsKey(_paramElectronArch))
                 {
                     electronArch = parser.Arguments[_paramElectronArch][0];

--- a/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <WarningLevel>4</WarningLevel>
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>dotnet-electronize</AssemblyName>
     <ToolCommandName>electronize</ToolCommandName>
 

--- a/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
 
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>dotnet-electronize</AssemblyName>
     <ToolCommandName>electronize</ToolCommandName>
 
@@ -33,7 +33,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <PlatformTarget>AnyCPU</PlatformTarget>
+    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/README.md
+++ b/README.md
@@ -137,10 +137,13 @@ There are additional platforms available:
 ```
 electronize build /target win
 electronize build /target osx
+electronize build /target osx-arm64
 electronize build /target linux
 ```
 
-Those three "default" targets will produce x64 packages for those platforms.
+Those four "default" targets will produce packages for those platforms.
+
+Note that the `osx-arm64` build requires that the project target `net6.0`. `osx-arm64` is for Apple Silicon Macs.
 
 For certain NuGet packages or certain scenarios you may want to build a pure x86 application. To support those things you can define the desired [.NET Core runtime](https://docs.microsoft.com/en-us/dotnet/core/rid-catalog), the [electron platform](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#platform) and [electron architecture](https://github.com/electron-userland/electron-packager/blob/master/docs/api.md#arch) like this:
 


### PR DESCRIPTION
While the current version works well with Rosetta 2, it is beneficial to be able to compile natively for ARM/Apple Silicon.

One issue that I would like input on is the switch from dotnet 5 to 6 for the CLI tools. Dotnet 6 is the minimum version to be able to target `osx-arm64` and switching the CLI tools to 6 allows for the tools to be compiled and run natively on arm. The changes that I made should still work fine with dotnet 5 and be able to compile for `osx-arm64` as long as dotnet 6 is also installed. It may also make more sense for this upgrade to be a separate pull request and upgrade all of the projects together to dotnet 6.