### PR TITLE
Allow ignoring certificate errors

### DIFF
--- a/ElectronNET.Host/main.js
+++ b/ElectronNET.Host/main.js
@@ -54,7 +54,7 @@ if (manifestJsonFile.singleInstance || manifestJsonFile.aspCoreBackendPort) {
         args.forEach(parameter => {
             const words = parameter.split('=');
 
-            if(words.length > 1) {
+            if (words.length > 1) {
                 app.commandLine.appendSwitch(words[0].replace('--', ''), words[1]);
             } else {
                 app.commandLine.appendSwitch(words[0].replace('--', ''));
@@ -72,6 +72,29 @@ if (manifestJsonFile.singleInstance || manifestJsonFile.aspCoreBackendPort) {
 
     if (!mainInstance) {
         app.quit();
+    }
+}
+
+// Bypass all SSL/TLS certificate errors. -- Less secure.
+if (manifestJsonFile.ignoreAllCertificateErrors) {
+    console.log('All SSL/TLS Certificate errors will be ignored.');
+    app.commandLine.appendSwitch('ignore-certificate-errors');
+}
+
+// Bypass SSL/TLS certificate errors only for the domain names specified in the electron.manifest.json file.
+if (manifestJsonFile.hasOwnProperty('domainNamesToIgnoreCertificateErrors')) {
+    if (manifestJsonFile.domainNamesToIgnoreCertificateErrors.length > 0) {
+        manifestJsonFile.domainNamesToIgnoreCertificateErrors.forEach(function (site) {
+            console.log('SSL/TLS certificate errors will be ignored for ' + site);
+        });
+
+        app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
+            if (shouldIgnoreCertificateForUrl(url)) {
+                console.log('SSL/TLS certificate error ignored for URL: ' + url);
+                event.preventDefault()
+                callback(true)
+            }
+        })
     }
 }
 
@@ -332,4 +355,16 @@ function getEnvironmentParameter() {
     }
 
     return '';
+}
+
+function shouldIgnoreCertificateForUrl(url) {
+    if (manifestJsonFile.hasOwnProperty('domainNamesToIgnoreCertificateErrors')) {
+        // Removing the scheme from the url so it will cover https and wss://
+        const urlWithoutScheme = url.replace(/(^\w+:|^)\/\//, '');
+        const sites = manifestJsonFile.domainNamesToIgnoreCertificateErrors.filter((oneSite) => urlWithoutScheme.startsWith(oneSite));
+
+        return sites.length > 0;
+    }
+
+    return false;
 }

--- a/ElectronNET.Host/main.js
+++ b/ElectronNET.Host/main.js
@@ -84,9 +84,7 @@ if (manifestJsonFile.ignoreAllCertificateErrors) {
 // Bypass SSL/TLS certificate errors only for the domain names specified in the electron.manifest.json file.
 if (manifestJsonFile.hasOwnProperty('domainNamesToIgnoreCertificateErrors')) {
     if (manifestJsonFile.domainNamesToIgnoreCertificateErrors.length > 0) {
-        manifestJsonFile.domainNamesToIgnoreCertificateErrors.forEach(function (site) {
-            console.log('SSL/TLS certificate errors will be ignored for ' + site);
-        });
+        console.log(`SSL/TLS certificate errors will be ignored for ${manifestJsonFile.domainNamesToIgnoreCertificateErrors.join(', ')}`);
 
         app.on('certificate-error', (event, webContents, url, error, certificate, callback) => {
             if (shouldIgnoreCertificateForUrl(url)) {


### PR DESCRIPTION
The Electron app fails when using a self-signed certificate for https communications with its ASP.NET Core backend. The native electron framework allows to ignore or bypass certificate errors. I am exposing this feature to Electron.NET

There will be two ways to bypass certificate errors:
1. By adding this flag to the electron.manifest.json file: `"ignoreAllCertificateErrors": true` it will allow to ignore all cert errors. This option is less secure

2. By adding a list of domain names that we want to ignore certificate errors for in the electron.manifest.json file:
```
  "domainNamesToIgnoreCertificateErrors": [
    "localhost",
    "127.0.0.1",
    "www.insecure.site.com"
  ],
```
