### PR TITLE
Support for .NET 6

### DIFF
--- a/ElectronNET.API/ElectronNET.API.csproj
+++ b/ElectronNET.API/ElectronNET.API.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageOutputPath>..\artifacts</PackageOutputPath>
     <PackageId>ElectronNET.API</PackageId>
@@ -10,8 +9,10 @@
     <Product>Electron.NET</Product>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/ElectronNET/Electron.NET/</PackageProjectUrl>
-    <Description>Building cross platform electron based desktop apps with .NET Core and ASP.NET Core.
-This package contains the API to access the "native" electron API.</Description>
+    <Description>
+      Building cross platform electron based desktop apps with .NET Core and ASP.NET Core.
+      This package contains the API to access the "native" electron API.
+    </Description>
     <RepositoryUrl>https://github.com/ElectronNET/Electron.NET/</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
@@ -20,6 +21,7 @@ This package contains the API to access the "native" electron API.</Description>
     <PackageIcon>PackageIcon.png</PackageIcon>
     <Version>99.0.0.0</Version>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -33,15 +35,16 @@ This package contains the API to access the "native" electron API.</Description>
     <Exec Command="$(ProjectDir)devCleanup.sh" IgnoreExitCode="true" />
   </Target>
   <ItemGroup>
-   <FrameworkReference Include="Microsoft.AspNetCore.App" />
-</ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SocketIoClientDotNet" Version="1.0.5" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+    <PackageReference Include="System.Drawing.Common" Version="5.*" Condition="'$(TargetFramework)' == 'net5.0'" />
+    <PackageReference Include="System.Drawing.Common" Version="6.*" Condition="'$(TargetFramework)' == 'net6.0'" />
   </ItemGroup>
 
 </Project>

--- a/ElectronNET.API/runtimeconfig.json
+++ b/ElectronNET.API/runtimeconfig.json
@@ -1,0 +1,7 @@
+{
+	"runtimeOptions": {
+		"configProperties": {
+			"System.Drawing.EnableUnixSupport": true
+		}
+	}
+}

--- a/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -14,6 +14,7 @@ namespace ElectronNET.CLI.Commands
         public static string COMMAND_ARGUMENTS = "Needed: '/target' with params 'win/osx/linux' to build for a typical app or use 'custom' and specify .NET Core build config & electron build config" + Environment.NewLine +
                                                  " for custom target, check .NET Core RID Catalog and Electron build target/" + Environment.NewLine +
                                                  " e.g. '/target win' or '/target custom \"win7-x86;win\"'" + Environment.NewLine +
+                                                 "Optional: '/dotnet-project' with the desired project file to build" + Environment.NewLine +
                                                  "Optional: '/dotnet-configuration' with the desired .NET Core build config e.g. release or debug. Default = Release" + Environment.NewLine +
                                                  "Optional: '/electron-arch' to specify the resulting electron processor architecture (e.g. ia86 for x86 builds). Be aware to use the '/target custom' param as well!" + Environment.NewLine +
                                                  "Optional: '/electron-params' specify any other valid parameter, which will be routed to the electron-packager." + Environment.NewLine +
@@ -35,6 +36,7 @@ namespace ElectronNET.CLI.Commands
         }
 
         private string _paramTarget = "target";
+        private string _paramDotNetProject = "dotnet-project";
         private string _paramDotNetConfig = "dotnet-configuration";
         private string _paramElectronArch = "electron-arch";
         private string _paramElectronParams = "electron-params";
@@ -106,8 +108,14 @@ namespace ElectronNET.CLI.Commands
                 
                 var dotNetPublishFlags = GetDotNetPublishFlags(parser);
 
+                var project = string.Empty;
+                if (parser.Arguments.ContainsKey(_paramDotNetProject))
+                {
+                    project = parser.Arguments[_paramDotNetProject][0];
+                }
+
                 var command =
-                    $"dotnet publish -r {platformInfo.NetCorePublishRid} -c \"{configuration}\" --output \"{tempBinPath}\" {string.Join(' ', dotNetPublishFlags.Select(kvp => $"{kvp.Key}={kvp.Value}"))} --self-contained";
+                    $"dotnet publish {project} -r {platformInfo.NetCorePublishRid} -c \"{configuration}\" --output \"{tempBinPath}\" {string.Join(' ', dotNetPublishFlags.Select(kvp => $"{kvp.Key}={kvp.Value}"))} --self-contained";
                 
                 // output the command 
                 Console.ForegroundColor = ConsoleColor.Green;

--- a/ElectronNET.CLI/Commands/StartElectronCommand.cs
+++ b/ElectronNET.CLI/Commands/StartElectronCommand.cs
@@ -23,6 +23,7 @@ namespace ElectronNET.CLI.Commands
         }
 
         private string _aspCoreProjectPath = "project-path";
+        private string _paramDotNetProject = "dotnet-project";
         private string _arguments = "args";
         private string _manifest = "manifest";
         private string _clearCache = "clear-cache";
@@ -105,9 +106,15 @@ namespace ElectronNET.CLI.Commands
                     configuration = parser.Arguments[_paramDotNetConfig][0];
                 }
 
+                var project = string.Empty;
+                if (parser.Arguments.ContainsKey(_paramDotNetProject))
+                {
+                    project = parser.Arguments[_paramDotNetProject][0];
+                }
+
                 if (parser != null && !parser.Arguments.ContainsKey("watch"))
                 {
-                    resultCode = ProcessHelper.CmdExecute($"dotnet publish -r {platformInfo.NetCorePublishRid} -c \"{configuration}\" --output \"{tempBinPath}\" {publishReadyToRun} {publishSingleFile} --no-self-contained", aspCoreProjectPath);
+                    resultCode = ProcessHelper.CmdExecute($"dotnet publish {project} -r {platformInfo.NetCorePublishRid} -c \"{configuration}\" --output \"{tempBinPath}\" {publishReadyToRun} {publishSingleFile} --no-self-contained", aspCoreProjectPath);
                 }
 
                 if (resultCode != 0)

--- a/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -77,7 +77,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-
-    <TargetFramework>net5.0</TargetFramework>
     <AssemblyName>dotnet-electronize</AssemblyName>
     <ToolCommandName>electronize</ToolCommandName>
 
@@ -30,6 +28,7 @@
     <PackageIcon>PackageIcon.png</PackageIcon>
     <PackAsTool>true</PackAsTool>
     <StartupObject></StartupObject>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/ElectronNET.WebApp/ElectronNET.WebApp.NET5.csproj
+++ b/ElectronNET.WebApp/ElectronNET.WebApp.NET5.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ElectronNET.API\ElectronNET.API.csproj" />
+    <ProjectReference Include="..\ElectronNET.API\ElectronNET.API.csproj" AdditionalProperties="TargetFramework=net5.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Assets\electron.ico">

--- a/ElectronNET.WebApp/ElectronNET.WebApp.NET6.csproj
+++ b/ElectronNET.WebApp/ElectronNET.WebApp.NET6.csproj
@@ -1,0 +1,42 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
+    <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
+    <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
+    <TypeScriptToolsVersion>4.2</TypeScriptToolsVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Controllers\ManageWindowsController.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Remove="Views\Windows\HandleErrorCrashes.cshtml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="wwwroot\assets\" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ElectronNET.API\ElectronNET.API.csproj" AdditionalProperties="TargetFramework=net6.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Update="Assets\electron.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Assets\electron_32x32.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Update="ElectronHostHook\**\*.*">
+      <CopyToPublishDirectory>Never</CopyToPublishDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Update="electron.manifest.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/ElectronNET.sln
+++ b/ElectronNET.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectronNET.WebApp", "ElectronNET.WebApp\ElectronNET.WebApp.csproj", "{7C048379-401C-4345-B5E7-BE232DEA8157}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectronNET.WebApp.NET5", "ElectronNET.WebApp\ElectronNET.WebApp.NET5.csproj", "{7C048379-401C-4345-B5E7-BE232DEA8157}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectronNET.WebApp.NET6", "\\Mac\Home\Repos\Electron.NET\ElectronNET.WebApp\ElectronNET.WebApp.NET6.csproj", "{76F72AED-31F4-4289-AFB5-D7ECA84072B8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectronNET.API", "ElectronNET.API\ElectronNET.API.csproj", "{A78157BA-B754-45F1-969F-D6A513CA0E72}"
 EndProject
@@ -63,6 +65,10 @@ Global
 		{B33E9B82-B6B4-4DB0-B6EE-61CC34641518}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{B33E9B82-B6B4-4DB0-B6EE-61CC34641518}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{B33E9B82-B6B4-4DB0-B6EE-61CC34641518}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{76F72AED-31F4-4289-AFB5-D7ECA84072B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{76F72AED-31F4-4289-AFB5-D7ECA84072B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{76F72AED-31F4-4289-AFB5-D7ECA84072B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{76F72AED-31F4-4289-AFB5-D7ECA84072B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/ElectronNET.sln
+++ b/ElectronNET.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 15.0.27130.2027
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectronNET.WebApp.NET5", "ElectronNET.WebApp\ElectronNET.WebApp.NET5.csproj", "{7C048379-401C-4345-B5E7-BE232DEA8157}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectronNET.WebApp.NET6", "\\Mac\Home\Repos\Electron.NET\ElectronNET.WebApp\ElectronNET.WebApp.NET6.csproj", "{76F72AED-31F4-4289-AFB5-D7ECA84072B8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectronNET.WebApp.NET6", "ElectronNET.WebApp\ElectronNET.WebApp.NET6.csproj", "{76F72AED-31F4-4289-AFB5-D7ECA84072B8}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ElectronNET.API", "ElectronNET.API\ElectronNET.API.csproj", "{A78157BA-B754-45F1-969F-D6A513CA0E72}"
 EndProject

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Well... there are lots of different approaches how to get a X-plat desktop app r
 
 ## 🛠 Requirements to run:
 
-The current Electron.NET CLI builds Windows/macOS/Linux binaries. Our API uses .NET 5, so our minimum base OS is the same as [.NET 5](https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0-supported-os.md).
+The current Electron.NET CLI builds Windows/macOS/Linux binaries. Our API multi-targets .NET 5 & .NET6, so our minimum base OS is the same as [.NET 5](https://github.com/dotnet/core/blob/master/release-notes/5.0/5.0-supported-os.md) or [.NET 6](https://github.com/dotnet/core/blob/main/release-notes/6.0/supported-os.md).
 
 Also you should have installed:
 

--- a/appveyor.cmd
+++ b/appveyor.cmd
@@ -1,0 +1,28 @@
+echo "Start building Electron.NET dev stack..."
+
+echo "Restore & Build API"
+cd ElectronNet.API
+dotnet restore
+dotnet build
+cd ..
+
+echo "Restore & Build CLI"
+cd ElectronNet.CLI
+dotnet restore
+dotnet build
+
+echo "Install CLI"
+
+dotnet tool uninstall ElectronNET.CLI -g
+dotnet tool install ElectronNET.CLI -g
+cd ..
+
+echo "Restore & Build WebApp Demo"
+cd ElectronNet.WebApp
+dotnet restore ElectronNet.WebApp.NET5.csproj
+dotnet build ElectronNet.WebApp.NET5.csproj
+
+echo "Invoke electronize build in WebApp Demo"
+
+echo "/target win (dev-build)"
+electronize build /target win /dotnet-project ElectronNet.WebApp.NET5.csproj /electron-params "--publish never"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 1.0.{build}
 image: Visual Studio 2022
 build_script:
-- cmd: buildAll.cmd
+- cmd: appveyor.cmd
 pull_requests:
   do_not_increment_build_number: true
 artifacts:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2019
+image: Visual Studio 2022
 build_script:
 - cmd: buildAll.cmd
 pull_requests:

--- a/buildAll.cmd
+++ b/buildAll.cmd
@@ -5,32 +5,34 @@ cd ElectronNet.API
 dotnet restore
 dotnet build
 cd ..
+
 echo "Restore & Build CLI"
 cd ElectronNet.CLI
 dotnet restore
 dotnet build
-cd ..
-echo "Restore & Build WebApp Demo"
-cd ElectronNet.WebApp
-dotnet restore
-dotnet build
-
-echo "Invoke electronize build in WebApp Demo"
 
 echo "Install CLI"
 
 dotnet tool uninstall ElectronNET.CLI -g
 dotnet tool install ElectronNET.CLI -g
+cd ..
+
+echo "Restore & Build WebApp Demo"
+cd ElectronNet.WebApp
+dotnet restore ElectronNet.WebApp.NET5.csproj
+dotnet build ElectronNet.WebApp.NET5.csproj
+
+echo "Invoke electronize build in WebApp Demo"
 
 echo "/target xxx (dev-build)"
-electronize build /target custom win7-x86;win /dotnet-configuration Debug /electron-arch ia32  /electron-params "--publish never"
+electronize build /target custom win7-x86;win /dotnet-project ElectronNet.WebApp.NET5.csproj /dotnet-configuration Debug /electron-arch ia32  /electron-params "--publish never"
 
 echo "/target win (dev-build)"
-electronize build /target win /electron-params "--publish never"
+electronize build /target win /dotnet-project ElectronNet.WebApp.NET5.csproj /electron-params "--publish never"
 
 echo "/target custom win7-x86;win (dev-build)"
 
-electronize build /target custom win7-x86;win /electron-params "--publish never"
+electronize build /target custom win7-x86;win /dotnet-project ElectronNet.WebApp.NET5.csproj /electron-params "--publish never"
 
 :: Be aware, that for non-electronnet-dev environments the correct 
 :: invoke command would be dotnet electronize ...

--- a/buildAll.sh
+++ b/buildAll.sh
@@ -1,16 +1,29 @@
 # flag arguments to target specific builds are available.
 
 # sh ./buildAll.sh
+
 # sh ./buildAll.sh -t osx
 # sh ./buildAll.sh -t win
 # sh ./buildAll.sh -t linux
 
+# sh ./buildAll.sh -t osx -p *.NET5.csproj
+# sh ./buildAll.sh -t win -p *.NET5.csproj
+# sh ./buildAll.sh -t linux -p *.NET5.csproj
+
+# sh ./buildAll.sh -t osx -p *.NET6.csproj
+# sh ./buildAll.sh -t win -p *.NET6.csproj
+# sh ./buildAll.sh -t linux -p *.NET6.csproj
+
 target=default
-while getopts t: flag; do
+project="*.NET5.cspoj"
+while getopts t:p: flag; do
     case "${flag}" in
     t) target=${OPTARG} ;;
+    p) project=${OPTARG} ;;
     esac
 done
+
+echo "Targeting $target & Project $project"
 
 dir=$(cd -P -- "$(dirname -- "$0")" && pwd -P)
 echo "Start building Electron.NET dev stack..."
@@ -31,38 +44,37 @@ echo "Restore & Build CLI"
 pushd $dir/ElectronNET.CLI
     dotnet restore
     dotnet build
+    
+    echo "Install CLI as dotnet tool"
+    dotnet tool uninstall ElectronNET.CLI -g
+    dotnet tool install ElectronNET.CLI -g
 popd
 
 echo "Restore & Build WebApp Demo"
 pushd $dir/ElectronNET.WebApp
-    dotnet restore
-    dotnet build
-
-    echo "Install CLI as dotnet tool"
-
-    dotnet tool uninstall ElectronNET.CLI -g
-    dotnet tool install ElectronNET.CLI -g
+    dotnet restore $project
+    dotnet build $project
 
     echo "Invoke electronize build in WebApp Demo"
 
     if [[ "$target" != "default" ]]; then
         echo "/target $target (dev-build)"
-        electronize build /target $target
+        electronize build /target $target /dotnet-project $project
     else
         echo "/target win (dev-build)"
-        electronize build /target win
+        electronize build /target win /dotnet-project $project
 
         echo "/target linux (dev-build)"
-        electronize build /target linux
+        electronize build /target linux /dotnet-project $project
 
         # Cannot publish osx/win on windows due to:
         # NETSDK1095: Optimizing assemblies for performance is not supported for the selected target platform or architecture.
         if [[ "$OSTYPE" != "linux-gnu"* ]]; then
             echo "/target osx (dev-build)"
-            electronize build /target osx
+            electronize build /target osx /dotnet-project $project
 
             echo "/target custom win7-x86;win (dev-build)"
-            electronize build /target custom "win7-x86;win"
+            electronize build /target custom "win7-x86;win" /dotnet-project $project
         fi
     fi
 popd

--- a/start.cmd
+++ b/start.cmd
@@ -1,8 +1,8 @@
 echo Bundle ASP.NET Core Project into EXE
 
 cd ElectronNET.WebApp
-dotnet restore
-dotnet publish -r win-x64 --output ../ElectronNET.Host/bin/
+dotnet restore *.NET5.csproj
+dotnet publish *.NET5.csproj -r win-x64 --output ../ElectronNET.Host/bin/
 
 echo Start Electron with bundled EXE
 cd ..\ElectronNET.Host

--- a/start.sh
+++ b/start.sh
@@ -1,8 +1,8 @@
 echo Bundle ASP.NET Core Project into EXE
 
 cd ElectronNET.WebApp
-dotnet restore
-dotnet publish -r osx-x64 --output ../ElectronNET.Host/bin/
+dotnet restore *.NET5.csproj
+dotnet publish *.NET5.csproj -r osx-x64 --output ../ElectronNET.Host/bin/
 
 echo Start Electron with bundled EXE
 cd ../ElectronNET.Host


### PR DESCRIPTION
* NET 6 Support
* Target a specific project in the `electronize build/start` command using `/dotnet-project <projectName>.csproj`

NOTE: the .NET6 runtime has targeted System.Drawing.Common at windows architectures and will cause warnings.  This should be addressed at some time.

https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/system-drawing-common-windows-only
