### PR TITLE
Support for additional dotnet publish flags.

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,21 @@ For certain NuGet packages or certain scenarios you may want to build a pure x86
 electronize build /target custom "win7-x86;win32" /electron-arch ia32 
 ```
 
+### Additional DotNet Publish Flags
+
+For certain scenarios additional `dotnet publish` arguments may be required. To add additional publish flags use the `--` flag at the end of your command and add any additional publish flags after. For example if you want to skip the default nuget restore you can do that like this:
+
+```
+electronize build /target osx -- --no-restore
+```
+
+#### Self-Contained 
+> `--self-contained` is enabled by default, to disable use `--no-self-contained` or `--self-contained false`
+
+#### Ignored Flags
+> `-r|--runtime`, `-o|--output`, `-c|--configuration`, `--interactive` &amp; `-h|--help` are ignored by design
+
+
 The end result should be an electron app under your __/bin/desktop__ folder.
 
 ### Note


### PR DESCRIPTION
Many build scenarios and scripts require certain flags to succeed.  For example `nuget restore` might be required prior to running `electronize build` and support for the `--no-restore` flag in the generated publish command is required.  

This PR adds the capability to add any of the dotnet publish flags to the `electronize build` command by appending the command with `-- [--dotnet-publish-flag(s)]`

Backwards compatibility to keep current builds running is maintained by adding the `--self-contained` flag if not present or overridden by `--self-contained false|--no-self-contained`.  Additionally any other flags that are already built into the design of the command are ignored or stripped.