### PR TITLE
Conversion to use ImageSharp rather than System.Drawing.Common

### DIFF
--- a/ElectronNET.API/ElectronNET.API.csproj
+++ b/ElectronNET.API/ElectronNET.API.csproj
@@ -40,8 +40,8 @@ This package contains the API to access the "native" electron API.</Description>
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SixLabors.ImageSharp" Version="1.0.4" />
     <PackageReference Include="SocketIoClientDotNet" Version="1.0.5" />
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/ElectronNET.API/Entities/BitmapOptions.cs
+++ b/ElectronNET.API/Entities/BitmapOptions.cs
@@ -1,13 +1,20 @@
-﻿namespace ElectronNET.API.Entities
+﻿using System;
+
+namespace ElectronNET.API.Entities
 {
     /// <summary>
     /// 
     /// </summary>
+    [Obsolete("Use ImageOptions instead.")]
     public class BitmapOptions
     {
         /// <summary>
         /// Gets or sets the scale factor
         /// </summary>
-        public float ScaleFactor { get; set; } = 1.0f;
+        public float ScaleFactor { get; set; } = NativeImage.DefaultScaleFactor;
+        /// <summary>
+        /// Utility conversion for obsolete class
+        /// </summary>
+        public static implicit operator ImageOptions(BitmapOptions o) => new() {ScaleFactor = o.ScaleFactor};
     }
 }

--- a/ElectronNET.API/Entities/CreateFromBitmapOptions.cs
+++ b/ElectronNET.API/Entities/CreateFromBitmapOptions.cs
@@ -1,8 +1,11 @@
-﻿namespace ElectronNET.API.Entities
+﻿using System;
+
+namespace ElectronNET.API.Entities
 {
     /// <summary>
     /// 
     /// </summary>
+    [Obsolete("Use CreateOptions instead")]
     public class CreateFromBitmapOptions
     {
         /// <summary>
@@ -18,6 +21,12 @@
         /// <summary>
         /// Gets or sets the scalefactor
         /// </summary>
-        public float ScaleFactor { get; set; } = 1.0f;
+        public float ScaleFactor { get; set; } = NativeImage.DefaultScaleFactor;
+
+        /// <summary>
+        /// Utility conversion for obsolete class
+        /// </summary>
+        public static implicit operator CreateOptions(CreateFromBitmapOptions o) => new()
+            {Width = o.Width, Height = o.Height, ScaleFactor = o.ScaleFactor};
     }
 }

--- a/ElectronNET.API/Entities/CreateFromBufferOptions.cs
+++ b/ElectronNET.API/Entities/CreateFromBufferOptions.cs
@@ -1,8 +1,11 @@
+using System;
+
 namespace ElectronNET.API.Entities
 {
     /// <summary>
     /// 
     /// </summary>
+    [Obsolete("Use CreateOptions instead")]
     public class CreateFromBufferOptions
     {
         /// <summary>
@@ -18,6 +21,11 @@ namespace ElectronNET.API.Entities
         /// <summary>
         /// Gets or sets the scalefactor
         /// </summary>
-        public float ScaleFactor { get; set; } = 1.0f;
+        public float ScaleFactor { get; set; } = NativeImage.DefaultScaleFactor;
+        /// <summary>
+        /// Utility conversion for obsolete class
+        /// </summary>
+        public static implicit operator CreateOptions(CreateFromBufferOptions o) => new()
+            {Width = o.Width, Height = o.Height, ScaleFactor = o.ScaleFactor};
     }
 }

--- a/ElectronNET.API/Entities/CreateOptions.cs
+++ b/ElectronNET.API/Entities/CreateOptions.cs
@@ -1,9 +1,9 @@
 namespace ElectronNET.API.Entities
 {
     /// <summary>
-    /// 
+    /// Options for creating a new <see cref="NativeImage"/>
     /// </summary>
-    public class AddRepresentationOptions
+    public class CreateOptions
     {
         /// <summary>
         /// Gets or sets the width
@@ -19,15 +19,6 @@ namespace ElectronNET.API.Entities
         /// Gets or sets the scalefactor
         /// </summary>
         public float ScaleFactor { get; set; } = NativeImage.DefaultScaleFactor;
-
-        /// <summary>
-        /// Gets or sets the buffer
-        /// </summary>
-        public byte[] Buffer { get; set; }
-
-        /// <summary>
-        /// Gets or sets the dataURL
-        /// </summary>
-        public string DataUrl { get; set; } 
+        
     }
 }

--- a/ElectronNET.API/Entities/ImageOptions.cs
+++ b/ElectronNET.API/Entities/ImageOptions.cs
@@ -1,0 +1,13 @@
+namespace ElectronNET.API.Entities
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public class ImageOptions
+    {
+        /// <summary>
+        /// Gets or sets the scale factor
+        /// </summary>
+        public float ScaleFactor { get; set; } = NativeImage.DefaultScaleFactor;
+    }
+}

--- a/ElectronNET.API/Entities/NativeImageJsonConverter.cs
+++ b/ElectronNET.API/Entities/NativeImageJsonConverter.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.IO;
 using Newtonsoft.Json;
+using SixLabors.ImageSharp;
 
 namespace ElectronNET.API.Entities
 {
@@ -24,7 +24,7 @@ namespace ElectronNET.API.Entities
             foreach (var item in dict)
             {
                 var bytes = Convert.FromBase64String(item.Value);
-                newDictionary.Add(item.Key, Image.FromStream(new MemoryStream(bytes)));
+                newDictionary.Add(item.Key, Image.Load(new MemoryStream(bytes)));
             }
             return new NativeImage(newDictionary);
         }

--- a/ElectronNET.API/Entities/Size.cs
+++ b/ElectronNET.API/Entities/Size.cs
@@ -20,5 +20,17 @@
         /// The height.
         /// </value>
         public int Height { get; set; }
+        
+        /// <summary>
+        /// Utility implicit conversion
+        /// </summary>
+        public static implicit operator SixLabors.ImageSharp.Size(Size s) =>
+            new (s.Width, s.Height);
+
+        /// <summary>
+        /// Utility implicit conversion
+        /// </summary>
+        public static implicit operator Size(SixLabors.ImageSharp.Size s) =>
+            new (){Height = s.Height, Width = s.Width};
     }
 }

--- a/ElectronNET.API/Entities/ToBitmapOptions.cs
+++ b/ElectronNET.API/Entities/ToBitmapOptions.cs
@@ -1,13 +1,20 @@
-﻿namespace ElectronNET.API.Entities
+﻿using System;
+
+namespace ElectronNET.API.Entities
 {
     /// <summary>
     /// 
     /// </summary>
+    [Obsolete("Use ImageOptions instead.")]
     public class ToBitmapOptions
     {
         /// <summary>
         /// Gets or sets the scalefactor
         /// </summary>
-        public float ScaleFactor { get; set; } = 1.0f;
+        public float ScaleFactor { get; set; } = NativeImage.DefaultScaleFactor;
+        /// <summary>
+        /// Utility conversion for obsolete class
+        /// </summary>
+        public static implicit operator ImageOptions(ToBitmapOptions o) => new () {ScaleFactor = o.ScaleFactor};
     }
 }

--- a/ElectronNET.API/Entities/ToDataUrlOptions.cs
+++ b/ElectronNET.API/Entities/ToDataUrlOptions.cs
@@ -1,13 +1,20 @@
-﻿namespace ElectronNET.API.Entities
+﻿using System;
+
+namespace ElectronNET.API.Entities
 {
     /// <summary>
     /// 
     /// </summary>
+    [Obsolete("Use ImageOptions instead.")]
     public class ToDataUrlOptions
     {
         /// <summary>
         /// Gets or sets the scalefactor
         /// </summary>
-        public float ScaleFactor { get; set; } = 1.0f;
+        public float ScaleFactor { get; set; } = NativeImage.DefaultScaleFactor;
+        /// <summary>
+        /// Utility conversion for obsolete class
+        /// </summary>
+        public static implicit operator ImageOptions(ToDataUrlOptions o) => new () {ScaleFactor = o.ScaleFactor};
     }
 }

--- a/ElectronNET.API/Entities/ToPNGOptions.cs
+++ b/ElectronNET.API/Entities/ToPNGOptions.cs
@@ -1,13 +1,20 @@
-﻿namespace ElectronNET.API.Entities
+﻿using System;
+
+namespace ElectronNET.API.Entities
 {
     /// <summary>
     /// 
     /// </summary>
+    [Obsolete("Use ImageOptions instead.")]
     public class ToPNGOptions
     {
         /// <summary>
         /// Gets or sets the scalefactor
         /// </summary>
         public float ScaleFactor { get; set; } = 1.0f;
+        /// <summary>
+        /// Utility conversion for obsolete class
+        /// </summary>
+        public static implicit operator ImageOptions(ToPNGOptions o) => new () {ScaleFactor = o.ScaleFactor};
     }
 }


### PR DESCRIPTION
fixes #637 Conversion to use ImageSharp rather than System.Drawing.Common for cross platform compatibility.

Breaking Changes:

* `System.Drawing.Common` is dropped and `SixLabors.ImageSharp` is introduced.
* uses of `NativeImage.CreateFromBitmap(bitmap, options);` is no longer supported, will cause failed builds.

Unexpected Behaviors:

* uses `ToDataUrl` will always create png data urls, unexpected output may happen for those that manipulate this output expecting a different data url format.

Obsoletions:

* `CreateFromBitmapOptions` & `CreateFromBufferOptions` have been consolidated into `CreateOptions`. Implicit conversions added to ease transition.
* `ToBitmapOptions`, `ToDataUrlOptions`, `ToPngOptions` & `BitmapOptions` have been consolidated into `ImageOptions`. Implicit conversions added to ease transition.