### PR TITLE
Fixes issue #735 - paths are URL escaped

### DIFF
--- a/ElectronNET.API/Dialog.cs
+++ b/ElectronNET.API/Dialog.cs
@@ -55,12 +55,7 @@ namespace ElectronNET.API
                 BridgeConnector.Socket.Off("showOpenDialogComplete" + guid);
 
                 var result = ((JArray)filePaths).ToObject<string[]>();
-                var list = new List<string>();
-                foreach (var item in result)
-                {
-                    list.Add(HttpUtility.UrlDecode(item));
-                }
-                taskCompletionSource.SetResult(list.ToArray());
+                taskCompletionSource.SetResult(result);
             });
 
 


### PR DESCRIPTION
When selecting a path with special characters, they might get removed by the folder selection C#-side (see issue https://github.com/ElectronNET/Electron.NET/issues/735).

They are URL-decoded inside the ShowOpenDialogAsync method, which doesn't make sense: the decoding, if applicable, should be the responsibility of the JS side.

It's clearly not mandatory because other "dialog" methods, such as ShowSaveDialogAsync, don't use this UrlDecode and work fine.

This PR removes the URL decoding.


Re-creation of PR #736