### PR TITLE
Update WebPreferences's ContextIsolation default value to true

### DIFF
--- a/src/ElectronNET.API/Entities/WebPreferences.cs
+++ b/src/ElectronNET.API/Entities/WebPreferences.cs
@@ -173,7 +173,7 @@ namespace ElectronNET.API.Entities
 
         /// <summary>
         /// Whether to run Electron APIs and the specified preload script in a separate
-        /// JavaScript context. Defaults to false. The context that the preload script runs
+        /// JavaScript context. Defaults to true. The context that the preload script runs
         /// in will still have full access to the document and window globals but it will
         /// use its own set of JavaScript builtins (Array, Object, JSON, etc.) and will be
         /// isolated from any changes made to the global environment by the loaded page.The
@@ -182,11 +182,10 @@ namespace ElectronNET.API.Entities
         /// content to ensure the loaded content cannot tamper with the preload script and
         /// any Electron APIs being used. This option uses the same technique used by . You
         /// can access this context in the dev tools by selecting the 'Electron Isolated
-        /// Context' entry in the combo box at the top of the Console tab. This option is
-        /// currently experimental and may change or be removed in future Electron releases.
+        /// Context' entry in the combo box at the top of the Console tab.
         /// </summary>
-        [DefaultValue(false)]
-        public bool ContextIsolation { get; set; } = false;
+        [DefaultValue(true)]
+        public bool ContextIsolation { get; set; } = true;
 
         /// <summary>
         /// Whether to use native window.open(). Defaults to false. This option is currently experimental.


### PR DESCRIPTION
I've encountered the following error: "Error: contextBridge API can only be used when contextIsolation is enabled", even though  I did enable `ContextIsolation`.

In #411, the same issue was reported, and the problem was traced down to the fact that the default value of `ContextIsolation` was set to the wrong value, which made that attribute un-editable.

I then found out that the default value of `ContextIsolation` was changed from false to true since Electron 12, as noted [here](https://www.electronjs.org/docs/latest/tutorial/context-isolation#what-is-it), so I fixed it.