### PR TITLE
add run parameter to dotnet cmd

### DIFF
--- a/src/ElectronNET.Host/main.js
+++ b/src/ElectronNET.Host/main.js
@@ -286,6 +286,7 @@ function startAspCoreBackend(electronPort) {
     console.log('ASP.NET Core Port: ' + aspCoreBackendPort);
     loadURL = `http://localhost:${aspCoreBackendPort}`;
     const parameters = [
+      'run',
       getEnvironmentParameter(),
       `/electronPort=${electronPort}`,
       `/electronWebPort=${aspCoreBackendPort}`,


### PR DESCRIPTION
I've seen many people complaining about how the app is just displaying the splash screen after starting the app. This is an attempt to fix that.