### PR TITLE
WebContents: add executeJavaScript and dom-ready event

### DIFF
--- a/src/ElectronNET.API/WebContents.cs
+++ b/src/ElectronNET.API/WebContents.cs
@@ -245,6 +245,37 @@ public class WebContents
     }
 
     /// <summary>
+    /// Evaluates script code in page.
+    /// </summary>
+    /// <param name="code">The code to execute.</param>
+    /// <param name="userGesture">if set to <c>true</c> simulate a user gesture.</param>
+    /// <returns>The result of the executed code.</returns>
+    /// <remarks>
+    /// <para>
+    /// In the browser window some HTML APIs like `requestFullScreen` can only be
+    /// invoked by a gesture from the user. Setting `userGesture` to `true` will remove
+    /// this limitation.
+    /// </para>
+    /// <para>
+    /// Code execution will be suspended until web page stop loading.
+    /// </para>
+    /// </remarks>
+    public Task<object> ExecuteJavaScriptAsync(string code, bool userGesture = false)
+    {
+        var taskCompletionSource = new TaskCompletionSource<object>();
+
+        BridgeConnector.Socket.On("webContents-executeJavaScript-completed", (result) =>
+        {
+            BridgeConnector.Socket.Off("webContents-executeJavaScript-completed");
+            taskCompletionSource.SetResult(result);
+        });
+
+        BridgeConnector.Socket.Emit("webContents-executeJavaScript", Id, code, userGesture);
+
+        return taskCompletionSource.Task;
+    }
+
+    /// <summary>
     /// Is used to get the Url of the loaded page.
     /// It's usefull if a web-server redirects you and you need to know where it redirects. For instance, It's useful in case of Implicit Authorization.
     /// </summary>

--- a/src/ElectronNET.API/WebContents.cs
+++ b/src/ElectronNET.API/WebContents.cs
@@ -114,6 +114,35 @@ public class WebContents
 
     private event Action<InputEvent> _inputEvent;
 
+    /// <summary>
+    /// Emitted when the document in the top-level frame is loaded.
+    /// </summary>
+    public event Action OnDomReady
+    {
+        add
+        {
+            if (_domReady == null)
+            {
+                BridgeConnector.Socket.On("webContents-domReady" + Id, () =>
+                    {
+                        _domReady();
+                    });
+
+                BridgeConnector.Socket.Emit("register-webContents-domReady", Id);
+            }
+            _domReady += value;
+        }
+        remove
+        {
+            _domReady -= value;
+
+            if (_domReady == null)
+                BridgeConnector.Socket.Off("webContents-domReady" + Id);
+        }
+    }
+
+    private event Action _domReady;
+
     internal WebContents(int id)
     {
         Id = id;

--- a/src/ElectronNET.Host/api/webContents.js
+++ b/src/ElectronNET.Host/api/webContents.js
@@ -28,6 +28,16 @@ module.exports = (socket) => {
             }
         });
     });
+
+    socket.on('register-webContents-domReady', (id) => {
+        const browserWindow = getWindowById(id);
+
+        browserWindow.webContents.removeAllListeners('dom-ready');
+        browserWindow.webContents.on('dom-ready', () => {
+            electronSocket.emit('webContents-domReady' + id);
+        });
+    });
+    
     socket.on('webContentsOpenDevTools', (id, options) => {
         if (options) {
             getWindowById(id).webContents.openDevTools(options);

--- a/src/ElectronNET.Host/api/webContents.js
+++ b/src/ElectronNET.Host/api/webContents.js
@@ -65,6 +65,12 @@ module.exports = (socket) => {
             }
         });
     });
+
+    socket.on('webContents-executeJavaScript', async (id, code, userGesture = false) => {
+        const result = await getWindowById(id).webContents.executeJavaScript(code, userGesture);
+        electronSocket.emit('webContents-executeJavaScript-completed', result);
+    });
+    
     socket.on('webContents-getUrl', function (id) {
         const browserWindow = getWindowById(id);
         electronSocket.emit('webContents-getUrl' + id, browserWindow.webContents.getURL());

--- a/src/ElectronNET.Host/api/webContents.ts
+++ b/src/ElectronNET.Host/api/webContents.ts
@@ -74,6 +74,11 @@ export = (socket: Socket) => {
     });
   });
 
+  socket.on('webContents-executeJavaScript', async (id, code, userGesture = false) => {
+    const result = await getWindowById(id).webContents.executeJavaScript(code, userGesture);
+    electronSocket.emit('webContents-executeJavaScript-completed', result);
+  });
+
   socket.on('webContents-getUrl', function (id) {
     const browserWindow = getWindowById(id);
     electronSocket.emit('webContents-getUrl' + id, browserWindow.webContents.getURL());

--- a/src/ElectronNET.Host/api/webContents.ts
+++ b/src/ElectronNET.Host/api/webContents.ts
@@ -35,6 +35,15 @@ export = (socket: Socket) => {
     });
   });
 
+  socket.on('register-webContents-domReady', (id) => {
+    const browserWindow = getWindowById(id);
+
+    browserWindow.webContents.removeAllListeners('dom-ready');
+    browserWindow.webContents.on('dom-ready', () => {
+        electronSocket.emit('webContents-domReady' + id);
+    });
+  });
+
   socket.on('webContentsOpenDevTools', (id, options) => {
     if (options) {
       getWindowById(id).webContents.openDevTools(options);


### PR DESCRIPTION
I just needed these for porting an existing Electron app to Electron.NET.