### PR TITLE
Added OSX architecture detection

### DIFF
--- a/src/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
+++ b/src/ElectronNET.CLI/Commands/Actions/GetTargetPlatformInformation.cs
@@ -48,7 +48,7 @@ namespace ElectronNET.CLI.Commands.Actions
                     }
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                     {
-                        netCorePublishRid = "osx-x64";
+                        netCorePublishRid = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "osx-arm64" : "osx-x64";
                         electronPackerPlatform = "mac";
                     }
                     if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))


### PR DESCRIPTION
The platform information will detect whether the process is x64 or arm64 and will report correct runtime ID to the publish command.

This PR resolves #820. 