### PR TITLE
Update Display.cs to current spec

### DIFF
--- a/src/ElectronNET.API/Entities/Display.cs
+++ b/src/ElectronNET.API/Entities/Display.cs
@@ -6,17 +6,52 @@
     public class Display
     {
         /// <summary>
+        /// Can be available, unavailable, unknown.
+        /// </summary>
+        public string AccelerometerSupport { get; set; }
+
+        /// <summary>
         /// Gets or sets the bounds.
         /// </summary>
         /// <value>
-        /// The bounds.
+        /// The bounds of the display in DIP points.
         /// </value>
         public Rectangle Bounds { get; set; }
+
+        /// <summary>
+        /// The number of bits per pixel.
+        /// </summary>
+        public int ColorDepth { get; set; }
+
+        /// <summary>
+        /// Represent a color space (three-dimensional object which contains all realizable color combinations) for the purpose of color conversions.
+        /// </summary>
+        public string ColorSpace { get; set; }
+
+        /// <summary>
+        /// The number of bits per color component.
+        /// </summary>
+        public int DepthPerComponent { get; set; }
+
+        /// <summary>
+        /// The display refresh rate.
+        /// </summary>
+        public int DisplayFrequency { get; set; }
 
         /// <summary>
         /// Unique identifier associated with the display.
         /// </summary>
         public string Id { get; set; }
+
+        /// <summary>
+        /// true for an internal display and false for an external display.
+        /// </summary>
+        public bool Internal { get; set; }
+
+        /// <summary>
+        /// User-friendly label, determined by the platform.
+        /// </summary>
+        public string Label { get; set; }
 
         /// <summary>
         /// Can be 0, 90, 180, 270, represents screen rotation in clock-wise degrees.
@@ -29,17 +64,22 @@
         public int ScaleFactor { get; set; }
 
         /// <summary>
+        /// Can be available, unavailable, unknown.
+        /// </summary>
+        public string TouchSupport { get; set; }
+
+        /// <summary>
+        /// Whether or not the display is a monochrome display.
+        /// </summary>
+        public bool Monochrome { get; set; }
+
+        /// <summary>
         /// Gets or sets the size.
         /// </summary>
         /// <value>
         /// The size.
         /// </value>
         public Size Size { get; set; }
-
-        /// <summary>
-        /// Can be available, unavailable, unknown.
-        /// </summary>
-        public string TouchSupport { get; set; }
 
         /// <summary>
         /// Gets or sets the work area.


### PR DESCRIPTION
As you can see [here](https://www.electronjs.org/docs/latest/api/structures/display), the current Display.cs file in Electron.NET is not up to date. I've added all the missing fields (except for those which show up in the docs, but do not actually appear in the object we fetch from electron), and checked locally to see that it works.

One thing to note is that I did not change the `Id` value from `string` to `int`, because that caused the `Electron.Screen.GetAllDisplaysAsync()` method to hang forever, and changing it also means breaking backwards compatibility.