### PR TITLE
Fix huge memory waste in IpcMain.Once [IMPORTANT]

### DIFF
--- a/src/ElectronNET.API/IpcMain.cs
+++ b/src/ElectronNET.API/IpcMain.cs
@@ -117,7 +117,7 @@ namespace ElectronNET.API
         public void Once(string channel, Action<object> listener)
         {
             BridgeConnector.Socket.Emit("registerOnceIpcMainChannel", channel);
-            BridgeConnector.Socket.On(channel, (args) =>
+            BridgeConnector.Socket.Once<object>(channel, (args) =>
             {
                 List<object> objectArray = FormatArguments(args);
 


### PR DESCRIPTION
My app uses `IpcMain.Once` to wait for an "all good, next frame" message from the front end. It's updating data at rates well over 60fps, so I'm calling `IpcMain.Once` a lot. I noticed that since I started doing this, my memory usage went waaay up (from 40-50Mb to about 800Mb), so I started investigating memory dumps, and indeed, I found this object:
![image](https://github.com/ElectronNET/Electron.NET/assets/58216719/2f1dc316-1696-4a15-aaa0-6d0d7368924a)
Which I later traced to be the object holding all of the socket listeners.

To fix this issue, all I had to do was replace the `Socket.On` in `IpcMain.Once` with `Socket.Once<object>`, and my memory usage went back down to 40-50Mb.