### PR TITLE
Add /no-restore and SelfContained property support in CLI

### DIFF
--- a/src/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/src/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -15,6 +15,7 @@ namespace ElectronNET.CLI.Commands
                                                  " for custom target, check .NET Core RID Catalog and Electron build target/" + Environment.NewLine +
                                                  " e.g. '/target win' or '/target custom \"win7-x86;win\"'" + Environment.NewLine +
                                                  "Optional: '/dotnet-configuration' with the desired .NET Core build config e.g. release or debug. Default = Release" + Environment.NewLine +
+                                                 "Optional: '/no-restore' to disable nuget packages restore" + Environment.NewLine +
                                                  "Optional: '/electron-arch' to specify the resulting electron processor architecture (e.g. ia86 for x86 builds). Be aware to use the '/target custom' param as well!" + Environment.NewLine +
                                                  "Optional: '/electron-params' specify any other valid parameter, which will be routed to the electron-packager." + Environment.NewLine +
                                                  "Optional: '/relative-path' to specify output a subdirectory for output." + Environment.NewLine +
@@ -45,6 +46,8 @@ namespace ElectronNET.CLI.Commands
         private string _manifest = "manifest";
         private string _paramPublishReadyToRun = "PublishReadyToRun";
         private string _paramPublishSingleFile = "PublishSingleFile";
+        private string _paramSelfContained = "SelfContained";
+        private string _paramNoRestore = "no-restore";
         private string _paramVersion = "Version";
 
         public Task<bool> ExecuteAsync()
@@ -81,6 +84,10 @@ namespace ElectronNET.CLI.Commands
                     configuration = parser.Arguments[_paramDotNetConfig][0];
                 }
 
+                string noRestore = parser.Arguments.ContainsKey(_paramNoRestore)
+                    ? " --no-restore"
+                    : string.Empty;
+
                 var platformInfo = GetTargetPlatformInformation.Do(desiredPlatform, specifiedFromCustom);
 
                 Console.WriteLine($"Build ASP.NET Core App for {platformInfo.NetCorePublishRid}...");
@@ -107,7 +114,7 @@ namespace ElectronNET.CLI.Commands
                 var dotNetPublishFlags = GetDotNetPublishFlags(parser);
 
                 var command =
-                    $"dotnet publish -r {platformInfo.NetCorePublishRid} -c \"{configuration}\" --output \"{tempBinPath}\" {string.Join(' ', dotNetPublishFlags.Select(kvp => $"{kvp.Key}={kvp.Value}"))} --self-contained";
+                    $"dotnet publish -r {platformInfo.NetCorePublishRid} -c \"{configuration}\"{noRestore} --output \"{tempBinPath}\" {string.Join(' ', dotNetPublishFlags.Select(kvp => $"{kvp.Key}={kvp.Value}"))}";
                 
                 // output the command 
                 Console.ForegroundColor = ConsoleColor.Green;
@@ -212,6 +219,7 @@ namespace ElectronNET.CLI.Commands
             {
                 {"/p:PublishReadyToRun", parser.TryGet(_paramPublishReadyToRun, out var rtr) ? rtr[0] : "true"},
                 {"/p:PublishSingleFile", parser.TryGet(_paramPublishSingleFile, out var psf) ? psf[0] : "true"},
+                {"/p:SelfContained", parser.TryGet(_paramSelfContained, out var sc) ? sc[0] : "true"},
             };
 
             if (parser.Arguments.ContainsKey(_paramVersion))


### PR DESCRIPTION
`/no-restore`
It's that MSBuild doesn't have property to control restore policies. These command are implemented in dotnet cli but not in MSBuild.
/no-restore option can be useful for flexlible control in CI\CD pipelines.

`SelfContained`
Optional --self-contained arg will be useful to reduce package size if the required .net runtime is expected to be installed.

The new options maintain backward compatibilty.

