### PR TITLE
Get back net6 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
+          6.0.x
           8.0.x
 
     - name: Build
@@ -32,6 +33,7 @@ jobs:
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: |
+          6.0.x
           8.0.x
 
     - name: Build

--- a/nuke/Build.cs
+++ b/nuke/Build.cs
@@ -71,6 +71,8 @@ class Build : NukeBuild
         }        
     }
 
+    string Framework => Solution.GetProject(DemoTargetLibName).GetProperty("TargetFramework");
+
     protected override void OnBuildInitialized()
     {
         var parser = new ReleaseNotesParser();
@@ -184,7 +186,9 @@ class Build : NukeBuild
             var cli = SourceDirectory / CliTargetLibName / $"{CliTargetLibName}.csproj";
             var args = "build /target custom win7-x86;win /dotnet-configuration Debug /electron-arch ia32  /electron-params \"--publish never\"";
 
-            DotNet($"run --project {cli} -- {args}", sample);
+            var cmd = $"run --project {cli} --framework {Framework} -- {args}";
+            Log.Debug(cmd);
+            DotNet(cmd, sample);
         });
 
     Target ElectronizeWindowsTargetSample => _ => _
@@ -195,7 +199,9 @@ class Build : NukeBuild
             var cli = SourceDirectory / CliTargetLibName / $"{CliTargetLibName}.csproj";
             var args = "build /target win /electron-params \"--publish never\"";
 
-            DotNet($"run --project {cli} -- {args}", sample);
+            var cmd =$"run --project {cli} --framework {Framework} -- {args}";
+            Log.Debug(cmd);
+            DotNet(cmd, sample);
         });
 
     Target ElectronizeCustomWin7TargetSample => _ => _
@@ -206,7 +212,9 @@ class Build : NukeBuild
             var cli = SourceDirectory / CliTargetLibName / $"{CliTargetLibName}.csproj";
             var args = "build /target custom win7-x86;win /electron-params \"--publish never\"";
 
-            DotNet($"run --project {cli} -- {args}", sample);
+            var cmd =$"run --project {cli} --framework {Framework} -- {args}";
+            Log.Debug(cmd);
+            DotNet(cmd, sample);
         });
 
     Target ElectronizeMacOsTargetSample => _ => _
@@ -217,7 +225,9 @@ class Build : NukeBuild
             var cli = SourceDirectory / CliTargetLibName / $"{CliTargetLibName}.csproj";
             var args = "build /target osx /electron-params \"--publish never\"";
 
-            DotNet($"run --project {cli} -- {args}", sample);
+            var cmd =$"run --project {cli} --framework {Framework} -- {args}";
+            Log.Debug(cmd);
+            DotNet(cmd, sample);
         });
 
     Target ElectronizeLinuxTargetSample => _ => _
@@ -228,7 +238,9 @@ class Build : NukeBuild
             var cli = SourceDirectory / CliTargetLibName / $"{CliTargetLibName}.csproj";
             var args = "build /target linux /electron-params \"--publish never\"";
 
-            DotNet($"run --project {cli} -- {args}", sample);
+            var cmd =$"run --project {cli} --framework {Framework} -- {args}";
+            Log.Debug(cmd);
+            DotNet(cmd, sample);
         });
 
     Target PublishPackages => _ => _

--- a/src/ElectronNET.API/ElectronNET.API.csproj
+++ b/src/ElectronNET.API/ElectronNET.API.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
     <PackageId>ElectronNET.API</PackageId>
     <Authors>Gregor Biswanger, Florian Rappl</Authors>

--- a/src/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/src/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <AssemblyName>dotnet-electronize</AssemblyName>
     <ToolCommandName>electronize</ToolCommandName>
     <PackageType>DotnetCliTool</PackageType>
@@ -25,7 +25,6 @@
     <PackageReleaseNotes>Changelog: https://github.com/ElectronNET/Electron.NET/blob/main/Changelog.md</PackageReleaseNotes>
     <PackageIcon>PackageIcon.png</PackageIcon>
     <PackAsTool>true</PackAsTool>
-    <PublishSelfContained>true</PublishSelfContained>
     <StartupObject>
     </StartupObject>
   </PropertyGroup>


### PR DESCRIPTION
.NET6 support is valid until [November 12, 2024](https://dotnet.microsoft.com/en-us/platform/support/policy), more than half a year, I'm not sure this is a good idea to abandon .NET6 support in Electron.NET.

I would like to suggest making the project multitarget and support both LTS versions (.NET6 and .NET8)

dotnet tool doesn't support self-contaied tools (see https://github.com/dotnet/sdk/issues/9565), so that `<PublishSelfContained>true</PublishSelfContained>` can be useful only for binaries but not for dotnet tool so I decided to remove the line