### PR TITLE
Set fixed eletron-builder version

### DIFF
--- a/src/ElectronNET.CLI/Commands/BuildCommand.cs
+++ b/src/ElectronNET.CLI/Commands/BuildCommand.cs
@@ -205,8 +205,7 @@ namespace ElectronNET.CLI.Commands
                         : $"node build-helper.js {manifestFileName} {version}", tempPath);
 
                 Console.WriteLine($"Package Electron App for Platform {platformInfo.ElectronPackerPlatform}...");
-                ProcessHelper.CmdExecute($"npx electron-builder@24.13.3 --config=./bin/electron-builder.json --{platformInfo.ElectronPackerPlatform} --{electronArch} -c.electronVersion=23.2.0 {electronParams}", tempPath);
-
+                ProcessHelper.CmdExecute($"npx electron-builder@24.13.3 --config=./bin/electron-builder.json --{platformInfo.ElectronPackerPlatform} --{electronArch} -c.electronVersion=30.0.3 {electronParams}", tempPath);
 
                 Console.WriteLine("... done");
 


### PR DESCRIPTION
Set fixed electron-builder version to avaoid third party dependency errors

Related to #854 