### PR TITLE
fix #767 - Added Electron version management and package.json updates.

### DIFF
--- a/src/ElectronNET.CLI/Commands/StartElectronCommand.cs
+++ b/src/ElectronNET.CLI/Commands/StartElectronCommand.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using System.Text.Json;
 using ElectronNET.CLI.Commands.Actions;
 
 namespace ElectronNET.CLI.Commands
@@ -117,6 +118,16 @@ namespace ElectronNET.CLI.Commands
                 }
 
                 DeployEmbeddedElectronFiles.Do(tempPath);
+
+                // Update package.json with electronVersion from manifest before npm install
+                string manifestFileName = "electron.manifest.json";
+                if (parser.Arguments.ContainsKey(_manifest))
+                {
+                    manifestFileName = parser.Arguments[_manifest].First();
+                }
+
+                // Execute build-helper.js to update package.json before npm install
+                ProcessHelper.CmdExecute($"node build-helper.js {manifestFileName}", tempPath);
 
                 var nodeModulesDirPath = Path.Combine(tempPath, "node_modules");
 

--- a/src/ElectronNET.CLI/ElectronNET.CLI.csproj
+++ b/src/ElectronNET.CLI/ElectronNET.CLI.csproj
@@ -8,7 +8,7 @@
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
     <PackageId>ElectronNET.CLI</PackageId>
     <!-- Version 99 is just set for local development stuff to avoid a conflict with "real" packages on NuGet.org -->
-    <Version>99.0.0.0</Version>
+    <Version>23.6.2-messe</Version>
     <Authors>Gregor Biswanger, Florian Rappl</Authors>
     <Product>Electron.NET</Product>
     <Company />

--- a/src/ElectronNET.Host/build-helper.js
+++ b/src/ElectronNET.Host/build-helper.js
@@ -8,20 +8,40 @@ const builderConfiguration = { ...manifestFile.build };
 if(process.argv.length > 3) {
     builderConfiguration.buildVersion = process.argv[3];
 }
+
+// @ts-ignore
+const packageJson = require('./package');
+
+// Update package.json if buildVersion is provided
 if(builderConfiguration.hasOwnProperty('buildVersion')) {
-    // @ts-ignore
-    const packageJson = require('./package');
     packageJson.name = dasherize(manifestFile.name || 'electron-net');
     packageJson.author = manifestFile.author || '';
     packageJson.version = builderConfiguration.buildVersion;
     packageJson.description = manifestFile.description || '';
+}
 
-    fs.writeFile('./package.json', JSON.stringify(packageJson), (error) => {
-        if(error) {
-            console.log(error.message);
-        }
-    });
-    
+// Update electron version if electronVersion is specified in manifest
+if(manifestFile.hasOwnProperty('electronVersion') && manifestFile.electronVersion) {
+    console.log(`Using Electron version ${manifestFile.electronVersion} from manifest`);
+    packageJson.devDependencies = packageJson.devDependencies || {};
+    packageJson.devDependencies.electron = `^${manifestFile.electronVersion}`;
+} else {
+    // If electronVersion is not specified, use a fallback version
+    const fallbackElectronVersion = "23.2.0";
+    console.log(`electronVersion not found in manifest, using fallback version ${fallbackElectronVersion}`);
+    packageJson.devDependencies = packageJson.devDependencies || {};
+    packageJson.devDependencies.electron = `^${fallbackElectronVersion}`;
+}
+
+// Write updated package.json
+fs.writeFile('./package.json', JSON.stringify(packageJson, null, 2), (error) => {
+    if(error) {
+        console.log(error.message);
+    }
+});
+
+// Update package-lock.json if it exists
+if(builderConfiguration.hasOwnProperty('buildVersion')) {
     try {
         // @ts-ignore
         const packageLockJson = require('./package-lock');

--- a/src/ElectronNET.WebApp/electron.manifest.json
+++ b/src/ElectronNET.WebApp/electron.manifest.json
@@ -5,6 +5,7 @@
   },
   "environment": "Production",
   "singleInstance": false,
+  "electronVersion": "23.2.0",
   "build": {
     "appId": "com.electronnetapidemos.app",
     "productName": "ElectronNET API Demos",


### PR DESCRIPTION
* BuildCommand.cs now reads the Electron version from the manifest file and updates package.json.
* StartElectronCommand.cs now reads the electronicVersion from the manifest file and updates package.json.
* Improved package.json updates and JSON response direction in build-helper.js.
* Added the electronicVersion property to Electron.manifest.json.