### PR TITLE
Develop

### DIFF
--- a/src/ElectronNET.Host/build-helper.js
+++ b/src/ElectronNET.Host/build-helper.js
@@ -8,20 +8,30 @@ const builderConfiguration = { ...manifestFile.build };
 if(process.argv.length > 3) {
     builderConfiguration.buildVersion = process.argv[3];
 }
+
+// @ts-ignore
+const packageJson = require('./package');
+
+// Update package.json if buildVersion is provided
 if(builderConfiguration.hasOwnProperty('buildVersion')) {
-    // @ts-ignore
-    const packageJson = require('./package');
     packageJson.name = dasherize(manifestFile.name || 'electron-net');
     packageJson.author = manifestFile.author || '';
     packageJson.version = builderConfiguration.buildVersion;
     packageJson.description = manifestFile.description || '';
 
-    fs.writeFile('./package.json', JSON.stringify(packageJson), (error) => {
+    // Write updated package.json
+    fs.writeFile('./package.json', JSON.stringify(packageJson, null, 2), (error) => {
         if(error) {
             console.log(error.message);
         }
     });
-    
+}
+
+// Note: electronVersion is now handled directly in C# before npm install
+// No need to update it here anymore
+
+// Update package-lock.json if it exists
+if(builderConfiguration.hasOwnProperty('buildVersion')) {
     try {
         // @ts-ignore
         const packageLockJson = require('./package-lock');

--- a/src/ElectronNET.WebApp/electron.manifest.json
+++ b/src/ElectronNET.WebApp/electron.manifest.json
@@ -5,6 +5,7 @@
   },
   "environment": "Production",
   "singleInstance": false,
+  "electronVersion": "25.9.0",
   "build": {
     "appId": "com.electronnetapidemos.app",
     "productName": "ElectronNET API Demos",


### PR DESCRIPTION
commit f69102e220628276806f0e8e01ab1ea483f80e3a
Author: Hyeonmin Seon <hmsun.es@esgroup.net>
Date:   Mon Aug 4 09:20:53 2025 +0900

Changed the Electron version update method in C# and updated the version

Changes:
    - Changed BuildCommand.cs to update the Electron version directly from C# code.
    - StartElectronCommand.cs reads the Electron version from the manifest file and updates package.json.
    - Removed the Electron version update logic from build-helper.js.
    - Updated the Electron version in electron.manifest.json from 23.2.0 to 25.9.0.

commit 855e8306c852231e8ec6afd172fc01adf2683aef
Author: Hyeonmin Seon <hmsun.es@esgroup.net>
Date:   Fri Aug 1 17:43:43 2025 +0900

Version Update: Changed to 23.6.2-messe

Changes:
    * The value of the `Version` element has changed from `99.0.0.0` to `23.6.2-messe`.
    * The package version has been updated to reflect new features and fixes.

commit 498ab0a6443d35560f164887a47fd05c6f6e6543
Author: Hyeonmin Seon <hmsun.es@esgroup.net>
Date:   Fri Aug 1 17:37:16 2025 +0900

    fix #767 - Added Electron version management and package.json updates.

    * BuildCommand.cs now reads the Electron version from the manifest file and updates package.json.
    * StartElectronCommand.cs now reads the electronicVersion from the manifest file and updates package.json.
    * Improved package.json updates and JSON response direction in build-helper.js.
    * Added the electronicVersion property to Electron.manifest.json.