### PR TITLE
Removed ownjsonSerializer from WindowManager

### DIFF
--- a/src/ElectronNET.API/API/WindowManager.cs
+++ b/src/ElectronNET.API/API/WindowManager.cs
@@ -153,12 +153,7 @@ namespace ElectronNET.API
                     options.X -= 7;
                 }
 
-                var ownjsonSerializer = new JsonSerializer()
-                {
-                    ContractResolver = new CamelCasePropertyNamesContractResolver(),
-                    NullValueHandling = NullValueHandling.Ignore
-                };
-                await BridgeConnector.Socket.Emit("createBrowserWindow", JObject.FromObject(options, ownjsonSerializer), loadUrl).ConfigureAwait(false);
+                await BridgeConnector.Socket.Emit("createBrowserWindow", JObject.FromObject(options, this._jsonSerializer), loadUrl).ConfigureAwait(false);
             }
 
             return await taskCompletionSource.Task.ConfigureAwait(false);
@@ -216,8 +211,7 @@ namespace ElectronNET.API
         private readonly JsonSerializer _jsonSerializer = new()
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
-            NullValueHandling = NullValueHandling.Ignore,
-            DefaultValueHandling = DefaultValueHandling.Ignore
+            NullValueHandling = NullValueHandling.Ignore
         };
     }
 }


### PR DESCRIPTION
Removed the unneeded serializer and applied the settings to the global this._jsonSerializer as when the X and Y values are -1 in the options it would lead to some settings not being applied. E.g. ContextIsolation with it now applying the default values when serializing, settings mentioned before are correctly assigned on Electron's end

In regards to #906 