### PR TITLE
Drop .NET 6.0, default to .NET 10.0 and update dependencies

### DIFF
--- a/nuke/_build.csproj
+++ b/nuke/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -11,9 +11,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Build" Version="17.11.48" />
-    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.11.48" />
-    <PackageReference Include="Nuke.Common" Version="9.0.4" />
+    <PackageReference Include="Microsoft.Build" Version="18.0.2" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.0.2" />
+    <PackageReference Include="Nuke.Common" Version="10.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElectronNET.API/ElectronNET.API.csproj
+++ b/src/ElectronNET.API/ElectronNET.API.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
     <PackageId>$(PackageNamePrefix).API</PackageId>
     <Title>$(PackageId)</Title>
@@ -28,8 +28,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SocketIOClient" Version="3.1.2" />
-    <PackageReference Include="System.Drawing.Common" Version="8.0.16" />
-    <PackageReference Include="System.Text.Json" Version="8.0.5" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
+    <PackageReference Include="System.Text.Json" Version="10.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElectronNET.AspNet/ElectronNET.AspNet.csproj
+++ b/src/ElectronNET.AspNet/ElectronNET.AspNet.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
     <PackageId>$(PackageNamePrefix).AspNet</PackageId>
     <Title>$(PackageId)</Title>
@@ -14,16 +14,10 @@
     <Nullable>disable</Nullable>
     <RootNamespace>ElectronNET</RootNamespace>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
-    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
     <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0|AnyCPU'">
-    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
     <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">

--- a/src/ElectronNET.Build/ElectronNET.Build.csproj
+++ b/src/ElectronNET.Build/ElectronNET.Build.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
     </ItemGroup>
 
 
@@ -25,11 +25,9 @@
             <OutputFiles Include="$(OutDir)**\*.dll"></OutputFiles>
         </ItemGroup>
 
-        <Message Text="Copy ElectronNET.Build.dll to destination: $(_DllTargetPath)" Importance="high"/>
+        <Message Text="Copy ElectronNET.Build.dll to destination: $(_DllTargetPath)" Importance="high" />
 
-        <Copy SourceFiles="@(OutputFiles)"
-              DestinationFolder="$(_DllTargetPath)\%(RecursiveDir)"
-              OverwriteReadOnlyFiles="true"></Copy>
+        <Copy SourceFiles="@(OutputFiles)" DestinationFolder="$(_DllTargetPath)\%(RecursiveDir)" OverwriteReadOnlyFiles="true"></Copy>
 
     </Target>
 

--- a/src/ElectronNET.ConsoleApp/ElectronNET.ConsoleApp.csproj
+++ b/src/ElectronNET.ConsoleApp/ElectronNET.ConsoleApp.csproj
@@ -8,7 +8,7 @@
   <Import Project="..\ElectronNET\build\ElectronNET.Core.props" Condition="$(ElectronNetDevMode)" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>exe</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/ElectronNET.ConsoleApp/Properties/PublishProfiles/linux-x64.pubxml
+++ b/src/ElectronNET.ConsoleApp/Properties/PublishProfiles/linux-x64.pubxml
@@ -7,7 +7,7 @@
     <PublishDir>publish\Release\net8.0\linux-x64</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/src/ElectronNET.ConsoleApp/Properties/PublishProfiles/publish-win-x64.pubxml
+++ b/src/ElectronNET.ConsoleApp/Properties/PublishProfiles/publish-win-x64.pubxml
@@ -12,7 +12,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <PublishUrl>publish\Release\net8.0\win-x64\</PublishUrl>
     <WebPublishMethod>FileSystem</WebPublishMethod>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
   </PropertyGroup>

--- a/src/ElectronNET.ConsoleApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/ElectronNET.ConsoleApp/Properties/PublishProfiles/win-x64.pubxml
@@ -7,7 +7,7 @@
     <PublishDir>publish\Release\net8.0\win-x64</PublishDir>
     <PublishProtocol>FileSystem</PublishProtocol>
     <_TargetId>Folder</_TargetId>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <PublishSingleFile>false</PublishSingleFile>

--- a/src/ElectronNET.Samples.ElectronHostHook/ElectronNET.Samples.ElectronHostHook.csproj
+++ b/src/ElectronNET.Samples.ElectronHostHook/ElectronNET.Samples.ElectronHostHook.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\ElectronNET\build\ElectronNET.Core.props" Condition="$(ElectronNetDevMode)" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
     <IsPackable>false</IsPackable>

--- a/src/ElectronNET.WebApp/ElectronNET.WebApp.csproj
+++ b/src/ElectronNET.WebApp/ElectronNET.WebApp.csproj
@@ -8,7 +8,7 @@
   <Import Project="..\ElectronNET\build\ElectronNET.Core.props" Condition="$(ElectronNetDevMode)" />
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <AspNetCoreModuleName>AspNetCoreModule</AspNetCoreModuleName>
   </PropertyGroup>

--- a/src/ElectronNET.WebApp/Properties/PublishProfiles/linux-x64.pubxml
+++ b/src/ElectronNET.WebApp/Properties/PublishProfiles/linux-x64.pubxml
@@ -11,7 +11,7 @@
     <WebPublishMethod>FileSystem</WebPublishMethod>
     <_TargetId>Folder</_TargetId>
     <SiteUrlToLaunchAfterPublish />
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <ProjectGuid>6ea447d9-343f-46b8-b456-66557bddbb9f</ProjectGuid>
     <SelfContained>true</SelfContained>

--- a/src/ElectronNET.WebApp/Properties/PublishProfiles/win-x64.pubxml
+++ b/src/ElectronNET.WebApp/Properties/PublishProfiles/win-x64.pubxml
@@ -11,7 +11,7 @@
     <WebPublishMethod>FileSystem</WebPublishMethod>
     <_TargetId>Folder</_TargetId>
     <SiteUrlToLaunchAfterPublish />
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <ProjectGuid>6ea447d9-343f-46b8-b456-66557bddbb9f</ProjectGuid>
     <SelfContained>true</SelfContained>

--- a/src/ElectronNET/ElectronNET.csproj
+++ b/src/ElectronNET/ElectronNET.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
     <PackageId>$(PackageNamePrefix)</PackageId>
     <Title>$(PackageId)</Title>


### PR DESCRIPTION
Updated all projects to target .NET 10.0, removing support for .NET 6.0. (Out of support since 1 year) 
.NET 6.0 is out of support since over 1 year, it makes no sense to build for it and is annoying if one does not have the 6.0 SDK installed.

Upgraded key dependencies, including:
- `Microsoft.Build` and `Microsoft.Build.Tasks.Core` to 18.0.2.
- `Nuke.Common` to 10.1.0.
- `System.Drawing.Common` to 10.0.1.
- `System.Text.Json` to 10.0.1.
