### PR TITLE
Partially revert "Drop .NET 6.0, default to .NET 10.0 and update dependencies"

### DIFF
--- a/src/ElectronNET.API/ElectronNET.API.csproj
+++ b/src/ElectronNET.API/ElectronNET.API.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
     <PackageId>$(PackageNamePrefix).API</PackageId>
     <Title>$(PackageId)</Title>
@@ -28,8 +28,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="SocketIOClient" Version="3.1.2" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.1" />
-    <PackageReference Include="System.Text.Json" Version="10.0.1" />
+    <PackageReference Include="System.Drawing.Common" Version="8.0.22" />
+    <PackageReference Include="System.Text.Json" Version="8.0.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElectronNET.AspNet/ElectronNET.AspNet.csproj
+++ b/src/ElectronNET.AspNet/ElectronNET.AspNet.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
     <PackageId>$(PackageNamePrefix).AspNet</PackageId>
     <Title>$(PackageId)</Title>
@@ -14,10 +14,16 @@
     <Nullable>disable</Nullable>
     <RootNamespace>ElectronNET</RootNamespace>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
+    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
     <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0|AnyCPU'">
+    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
     <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">

--- a/src/ElectronNET.Build/ElectronNET.Build.csproj
+++ b/src/ElectronNET.Build/ElectronNET.Build.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="18.0.2" />
+        <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.3.2" />
     </ItemGroup>
 
 
@@ -25,9 +25,11 @@
             <OutputFiles Include="$(OutDir)**\*.dll"></OutputFiles>
         </ItemGroup>
 
-        <Message Text="Copy ElectronNET.Build.dll to destination: $(_DllTargetPath)" Importance="high" />
+        <Message Text="Copy ElectronNET.Build.dll to destination: $(_DllTargetPath)" Importance="high"/>
 
-        <Copy SourceFiles="@(OutputFiles)" DestinationFolder="$(_DllTargetPath)\%(RecursiveDir)" OverwriteReadOnlyFiles="true"></Copy>
+        <Copy SourceFiles="@(OutputFiles)"
+              DestinationFolder="$(_DllTargetPath)\%(RecursiveDir)"
+              OverwriteReadOnlyFiles="true"></Copy>
 
     </Target>
 

--- a/src/ElectronNET/ElectronNET.csproj
+++ b/src/ElectronNET/ElectronNET.csproj
@@ -3,7 +3,7 @@
   <Import Project="..\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <PackageOutputPath>..\..\artifacts</PackageOutputPath>
     <PackageId>$(PackageNamePrefix)</PackageId>
     <Title>$(PackageId)</Title>


### PR DESCRIPTION
The key points are:

1. We have absolutely no need to drop .net6 support. It doesn't hurt us in any way
2. Many are still using .net6, including Electron.NET (non-Core) users. It doesn't make sense to force them to update two things at the same time (.net + Electron.NET
3. We MUST NOT and NEVER update `Microsoft.Build.Utilities.Core`. This will make Electron.NET stop working on older Visual Studio and MSBuild versions. There's are also no reasons to update it in the first place

I'd also like to note the MS saying "Out of support" has almost no practical meaning. I've never seen any bugs fixed in the same .net version which mattered to me. The bugs that all new .net versions have are much worse than mature .net versions which are declared as "out of support". 

Also, MS have become more lazy in recent .net versions about downlevel support. From one day to another, out .net8 MAUI builds have stopped building on CI with a message that it's unsupported and we should update to .net 10 - only few weeks after .net 10 has been released - that's insane. It's not MS to decide at what time we will update our software - and definitely not within a timeframe of 4 weeks.

I know that many others are thinking the same way and therefore we should not drop support for older .net versions when we don't have a better reason than some MS support declaration.