### PR TITLE
Combine and separate workflows

### DIFF
--- a/.github/workflows/Build and Publish.yml
+++ b/.github/workflows/Build and Publish.yml
@@ -1,33 +1,25 @@
-name: CI
+name: Build and Publish
 
-on: [push, pull_request]
+on: [push]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
+concurrency:
+  group: build-publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  # linux:
-  #   runs-on: ubuntu-latest
-  #   timeout-minutes: 10
+  Integration-Tests:
+    uses: ./.github/workflows/integration-tests.yml
+    name: '1'
 
-  #   steps:
-  #   - uses: actions/checkout@v4
-
-  #   - name: Setup dotnet
-  #     uses: actions/setup-dotnet@v4
-  #     with:
-  #       dotnet-version: |
-  #         6.0.x
-  #         8.0.x
-  #         10.0.x
-
-  #   - name: Build
-  #     run: ./build.sh
-
-  windows:
+  Publish:
+    needs: [Integration-Tests]
     runs-on: windows-latest
     timeout-minutes: 10
+    name: '2 / Publish'
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/PR Validation.yml
+++ b/.github/workflows/PR Validation.yml
@@ -1,0 +1,39 @@
+name: PR Validation
+
+on: [pull_request]
+
+concurrency:
+  group: pr-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  Whitespace-Check:
+    uses: ./.github/workflows/trailing-whitespace-check.yml
+    secrets: inherit
+    name: '1'
+    
+  Tests:
+    needs: Whitespace-Check
+    uses: ./.github/workflows/integration-tests.yml
+    secrets: inherit
+    name: '2'
+
+  build:
+    needs: [Whitespace-Check, Tests]
+    runs-on: windows-latest
+    timeout-minutes: 10
+    name: '3 / Build'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Setup dotnet
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: |
+          6.0.x
+          8.0.x
+          10.0.x
+
+    - name: Build
+      run: .\build.ps1

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,7 @@
-﻿name: Tests
+name: Tests
 
 on:
-  push:
-    branches: [ develop, main ]
-  pull_request:
-    branches: [ develop, main ]
+  workflow_call:
 
 concurrency:
   group: integration-tests-${{ github.ref }}
@@ -12,7 +9,7 @@ concurrency:
 
 jobs:
   tests:
-    name: Integration Tests (${{ matrix.os }} / Electron ${{ matrix.electronVersion }})
+    name: ${{ matrix.os }} API-${{ matrix.electronVersion }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -2,7 +2,7 @@ name: Create PR Comments
 
 on:
   workflow_run:
-    workflows: ["Tests"]
+    workflows: [ "PR Validation" ]
     types: [completed]
 
 permissions:
@@ -14,7 +14,7 @@ jobs:
   pr-comment:
     name: Post Test Result as PR comment
     runs-on: ubuntu-24.04
-    if: github.event.workflow_run.event == 'pull_request'
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion != 'cancelled'
 
     steps:
       - name: Download CTRF artifact

--- a/.github/workflows/retry-test-jobs.yml
+++ b/.github/workflows/retry-test-jobs.yml
@@ -1,8 +1,8 @@
-﻿name: Tests auto-rerun
+name: Tests auto-rerun
 
 on:
   workflow_run:
-    workflows: [ "Tests" ]
+    workflows: [ "PR Validation", "Build and Publish" ]
     types: [ completed ]
 
 jobs:
@@ -35,7 +35,7 @@ jobs:
           failed_matrix_jobs=$(echo "$jobs_json" | jq '
             [ .jobs[]
               | select(.conclusion == "failure"
-                       and (.name | startswith("Integration Tests (")))
+                       and (.name | contains(" API-")))
             ]
             | length
           ')

--- a/.github/workflows/trailing-whitespace-check.yml
+++ b/.github/workflows/trailing-whitespace-check.yml
@@ -1,11 +1,10 @@
-name: Trailing Whitespace Check
+name: Whitespace Check
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
+  workflow_call:
 
 jobs:
-  check-trailing-whitespace:
+  check-whitespace:
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/src/ElectronNET.sln
+++ b/src/ElectronNET.sln
@@ -41,10 +41,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Test Apps", "Test Apps", "{
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{985D39A7-5216-4945-8167-2FD0CB387BD8}"
 	ProjectSection(SolutionItems) = preProject
-		..\.github\workflows\ci.yml = ..\.github\workflows\ci.yml
+		..\.github\workflows\Build and Publish.yml = ..\.github\workflows\Build and Publish.yml
 		..\.github\workflows\integration-tests.yml = ..\.github\workflows\integration-tests.yml
+		..\.github\workflows\PR Validation.yml = ..\.github\workflows\PR Validation.yml
 		..\.github\workflows\pr-comment.yml = ..\.github\workflows\pr-comment.yml
 		..\.github\workflows\publish-wiki.yml = ..\.github\workflows\publish-wiki.yml
+		..\.github\workflows\retry-test-jobs.yml = ..\.github\workflows\retry-test-jobs.yml
 		..\.github\workflows\trailing-whitespace-check.yml = ..\.github\workflows\trailing-whitespace-check.yml
 	EndProjectSection
 EndProject


### PR DESCRIPTION

- Separate between PR and Push execution (with and without secrets)
- Turn tests into re-usable workflows and call them from the main ones
- Introduce a random delay to avoid "npm gateway timeout errors"
- Add a workflow to re-run failed test jobs

