### PR TITLE
Fix single instance broken

### DIFF
--- a/src/ElectronNET.API/Runtime/StartupManager.cs
+++ b/src/ElectronNET.API/Runtime/StartupManager.cs
@@ -167,11 +167,11 @@
 
                 if (isSingleInstance?.Length > 0 && bool.TryParse(isSingleInstance, out var isSingleInstanceActive) && isSingleInstanceActive)
                 {
-                    buildInfo.ElectronSingleInstance = "yes";
+                    buildInfo.ElectronSingleInstance = "true";
                 }
                 else
                 {
-                    buildInfo.ElectronSingleInstance = "no";
+                    buildInfo.ElectronSingleInstance = "false";
                 }
 
                 if (httpPort?.Length > 0 && int.TryParse(httpPort, out var port))

--- a/src/ElectronNET.Host/main.js
+++ b/src/ElectronNET.Host/main.js
@@ -93,7 +93,7 @@ app.on('will-finish-launching', () => {
 
 const manifestJsonFile = require(manifestJsonFilePath);
 
-if (manifestJsonFile.singleInstance === "yes") {
+if (manifestJsonFile.singleInstance === "true" || manifestJsonFile.singleInstance === "True") {
     const mainInstance = app.requestSingleInstanceLock();
     app.on('second-instance', (events, args = []) => {
         args.forEach((parameter) => {


### PR DESCRIPTION
I was debugging why my electron app does not respect the singleInstance property and found out that commit 688d6d83cc0d8f70ced6821a1bd0a5e12472e26f regressed the single instance behaviour.

Problem: Commit 688d6d83cc0d8f70ced6821a1bd0a5e12472e26f changed the check to == 'yes' but the configuration uses `true`.

