### PR TITLE
Move `custom_main.js` Handling to Execute Before Checking Command Line Switches

### DIFF
--- a/src/ElectronNET.Host/main.js
+++ b/src/ElectronNET.Host/main.js
@@ -24,26 +24,6 @@ let unpackeddotnet = false;
 let dotnetpacked = false;
 let electronforcedport;
 
-if (app.commandLine.hasSwitch('manifest')) {
-    manifestJsonFileName = app.commandLine.getSwitchValue('manifest');
-}
-
-console.log('Entry!!!:  ');
-
-if (app.commandLine.hasSwitch('unpackedelectron')) {
-    unpackedelectron = true;
-}
-else if (app.commandLine.hasSwitch('unpackeddotnet')) {
-    unpackeddotnet = true;
-}
-else if (app.commandLine.hasSwitch('dotnetpacked')) {
-    dotnetpacked = true;
-}
-
-if (app.commandLine.hasSwitch('electronforcedport')) {
-    electronforcedport = app.commandLine.getSwitchValue('electronforcedport');
-}
-
 // Custom startup hook: look for custom_main.js and invoke its onStartup(host) if present.
 // If the hook returns false, abort Electron startup.
 try {
@@ -65,6 +45,26 @@ try {
     }
 } catch (err) {
     console.error('Error while executing custom_main.js:', err);
+}
+
+if (app.commandLine.hasSwitch('manifest')) {
+    manifestJsonFileName = app.commandLine.getSwitchValue('manifest');
+}
+
+console.log('Entry!!!:  ');
+
+if (app.commandLine.hasSwitch('unpackedelectron')) {
+    unpackedelectron = true;
+}
+else if (app.commandLine.hasSwitch('unpackeddotnet')) {
+    unpackeddotnet = true;
+}
+else if (app.commandLine.hasSwitch('dotnetpacked')) {
+    dotnetpacked = true;
+}
+
+if (app.commandLine.hasSwitch('electronforcedport')) {
+    electronforcedport = app.commandLine.getSwitchValue('electronforcedport');
 }
 
 const currentPath = __dirname;


### PR DESCRIPTION
Proposed changes for #1029

Allows a custom `custom_main.js` script to manipulate electron command line switches before they are checked by the main host. No breaking changes for existing applications.