### PR TITLE
Changed facade to socket connection

### DIFF
--- a/src/ElectronNET.API/Bridge/BridgeConnector.cs
+++ b/src/ElectronNET.API/Bridge/BridgeConnector.cs
@@ -4,7 +4,7 @@ namespace ElectronNET.API
 {
     internal static class BridgeConnector
     {
-        public static SocketIoFacade Socket
+        public static ISocketConnection Socket
         {
             get
             {

--- a/src/ElectronNET.API/Bridge/ISocketConnection.cs
+++ b/src/ElectronNET.API/Bridge/ISocketConnection.cs
@@ -1,0 +1,56 @@
+namespace ElectronNET.API;
+
+using System;
+using System.Threading.Tasks;
+
+/// <summary>
+/// Common interface for communication facades.
+/// Provides methods for bidirectional communication between .NET and Electron.
+/// </summary>
+internal interface ISocketConnection : IDisposable
+{
+    /// <summary>
+    /// Raised when the bridge connection is established.
+    /// </summary>
+    event EventHandler BridgeConnected;
+
+    /// <summary>
+    /// Raised when the bridge connection is lost.
+    /// </summary>
+    event EventHandler BridgeDisconnected;
+
+    /// <summary>
+    /// Establishes the connection to Electron.
+    /// </summary>
+    void Connect();
+
+    /// <summary>
+    /// Registers a persistent event handler.
+    /// </summary>
+    void On(string eventName, Action action);
+
+    /// <summary>
+    /// Registers a persistent event handler with a typed parameter.
+    /// </summary>
+    void On<T>(string eventName, Action<T> action);
+
+    /// <summary>
+    /// Registers a one-time event handler.
+    /// </summary>
+    void Once(string eventName, Action action);
+
+    /// <summary>
+    /// Registers a one-time event handler with a typed parameter.
+    /// </summary>
+    void Once<T>(string eventName, Action<T> action);
+
+    /// <summary>
+    /// Removes an event handler.
+    /// </summary>
+    void Off(string eventName);
+
+    /// <summary>
+    /// Sends a message to Electron.
+    /// </summary>
+    Task Emit(string eventName, params object[] args);
+}

--- a/src/ElectronNET.API/Bridge/SocketIOConnection.cs
+++ b/src/ElectronNET.API/Bridge/SocketIOConnection.cs
@@ -8,13 +8,13 @@ using ElectronNET.API.Serialization;
 using SocketIO.Serializer.SystemTextJson;
 using SocketIO = SocketIOClient.SocketIO;
 
-internal class SocketIoFacade : IDisposable
+internal class SocketIOConnection : ISocketConnection
 {
     private readonly SocketIO _socket;
     private readonly object _lockObj = new object();
     private bool _isDisposed;
 
-    public SocketIoFacade(string uri)
+    public SocketIOConnection(string uri)
     {
         _socket = new SocketIO(uri);
         _socket.Serializer = new SystemTextJsonSerializer(ElectronJson.Options);
@@ -140,7 +140,7 @@ internal class SocketIoFacade : IDisposable
     {
         if (this._isDisposed)
         {
-            throw new ObjectDisposedException(nameof(SocketIoFacade));
+            throw new ObjectDisposedException(nameof(SocketIOConnection));
         }
     }
 }

--- a/src/ElectronNET.API/ElectronNetRuntime.cs
+++ b/src/ElectronNET.API/ElectronNetRuntime.cs
@@ -49,7 +49,7 @@
 
         internal static Func<Task> OnAppReadyCallback { get; set; }
 
-        internal static SocketIoFacade GetSocket()
+        internal static ISocketConnection GetSocket()
         {
             return RuntimeControllerCore?.Socket;
         }

--- a/src/ElectronNET.API/Runtime/Controllers/RuntimeControllerBase.cs
+++ b/src/ElectronNET.API/Runtime/Controllers/RuntimeControllerBase.cs
@@ -12,7 +12,7 @@
         {
         }
 
-        internal abstract SocketIoFacade Socket { get; }
+        internal abstract ISocketConnection Socket { get; }
 
         internal abstract ElectronProcessBase ElectronProcess { get; }
 

--- a/src/ElectronNET.API/Runtime/Controllers/RuntimeControllerDotNetFirst.cs
+++ b/src/ElectronNET.API/Runtime/Controllers/RuntimeControllerDotNetFirst.cs
@@ -19,7 +19,7 @@
         {
         }
 
-        internal override SocketIoFacade Socket
+        internal override ISocketConnection Socket
         {
             get
             {

--- a/src/ElectronNET.API/Runtime/Controllers/RuntimeControllerElectronFirst.cs
+++ b/src/ElectronNET.API/Runtime/Controllers/RuntimeControllerElectronFirst.cs
@@ -17,7 +17,7 @@
         {
         }
 
-        internal override SocketIoFacade Socket
+        internal override ISocketConnection Socket
         {
             get
             {

--- a/src/ElectronNET.API/Runtime/Services/SocketBridge/SocketBridgeService.cs
+++ b/src/ElectronNET.API/Runtime/Services/SocketBridge/SocketBridgeService.cs
@@ -9,7 +9,7 @@
     {
         private readonly int socketPort;
         private readonly string socketUrl;
-        private SocketIoFacade socket;
+        private SocketIOConnection socket;
 
         public SocketBridgeService(int socketPort)
         {
@@ -19,11 +19,11 @@
 
         public int SocketPort => this.socketPort;
 
-        internal SocketIoFacade Socket => this.socket;
+        internal SocketIOConnection Socket => this.socket;
 
         protected override Task StartCore()
         {
-            this.socket = new SocketIoFacade(this.socketUrl);
+            this.socket = new SocketIOConnection(this.socketUrl);
             this.socket.BridgeConnected += this.Socket_BridgeConnected;
             this.socket.BridgeDisconnected += this.Socket_BridgeDisconnected;
             Task.Run(this.Connect);

--- a/src/ElectronNET.AspNet/Runtime/Controllers/RuntimeControllerAspNetBase.cs
+++ b/src/ElectronNET.AspNet/Runtime/Controllers/RuntimeControllerAspNetBase.cs
@@ -25,7 +25,7 @@
 
         internal override SocketBridgeService SocketBridge => this.socketBridge;
 
-        internal override SocketIoFacade Socket
+        internal override ISocketConnection Socket
         {
             get
             {


### PR DESCRIPTION
Follow up for #1021: Introduces a new interface `ISocketConnection` and renames the facade to `SocketConnection`.

Exclusively uses the interfaces for the type.