### PR TITLE
ci: stop hanging PR workflows and remove duplicate runs

### DIFF
--- a/.github/workflows/Build and Publish.yml
+++ b/.github/workflows/Build and Publish.yml
@@ -1,6 +1,8 @@
 name: Build and Publish
 
-on: [push]
+on:
+  push:
+    branches: [main, develop]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,13 +4,14 @@ on:
   workflow_call:
 
 concurrency:
-  group: integration-tests-${{ github.ref }}
+  group: integration-tests-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   tests:
     name: ${{ matrix.os }} API-${{ matrix.electronVersion }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:
@@ -42,13 +43,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Random delay (0-20 seconds)
-        shell: bash
-        run: |
-          DELAY=$((RANDOM % 21))
-          echo "Waiting for $DELAY seconds..."
-          sleep $DELAY
-
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:
@@ -79,27 +73,31 @@ jobs:
       - name: Run tests (Linux)
         if: runner.os == 'Linux'
         continue-on-error: true
+        timeout-minutes: 15
         run: |
           mkdir -p test-results
           xvfb-run -a dotnet test src/ElectronNET.IntegrationTests/ElectronNET.IntegrationTests.csproj \
             -c Release --no-build -r ${{ matrix.rid }} -p:RuntimeIdentifier=${{ matrix.rid }} -p:ElectronVersion=${{ matrix.electronVersion }} \
             --logger "trx;LogFileName=${{ matrix.os }}-electron-${{ matrix.electronVersion }}.trx" \
             --logger "console;verbosity=detailed" \
+            --blame-hang --blame-hang-timeout 5min \
             --results-directory test-results
 
       - name: Run tests (Windows)
         if: runner.os == 'Windows'
         continue-on-error: true
+        timeout-minutes: 15
         run: |
           New-Item -ItemType Directory -Force -Path test-results | Out-Null
-          dotnet test src/ElectronNET.IntegrationTests/ElectronNET.IntegrationTests.csproj -c Release --no-build -r ${{ matrix.rid }} -p:RuntimeIdentifier=${{ matrix.rid }} -p:ElectronVersion=${{ matrix.electronVersion }} --logger "trx;LogFileName=${{ matrix.os }}-electron-${{ matrix.electronVersion }}.trx" --logger "console;verbosity=detailed" --results-directory test-results
+          dotnet test src/ElectronNET.IntegrationTests/ElectronNET.IntegrationTests.csproj -c Release --no-build -r ${{ matrix.rid }} -p:RuntimeIdentifier=${{ matrix.rid }} -p:ElectronVersion=${{ matrix.electronVersion }} --logger "trx;LogFileName=${{ matrix.os }}-electron-${{ matrix.electronVersion }}.trx" --logger "console;verbosity=detailed" --blame-hang --blame-hang-timeout 5min --results-directory test-results
 
       - name: Run tests (macOS)
         if: runner.os == 'macOS'
         continue-on-error: true
+        timeout-minutes: 15
         run: |
           mkdir -p test-results
-          dotnet test src/ElectronNET.IntegrationTests/ElectronNET.IntegrationTests.csproj -c Release --no-build -r ${{ matrix.rid }} -p:RuntimeIdentifier=${{ matrix.rid }} -p:ElectronVersion=${{ matrix.electronVersion }} --logger "trx;LogFileName=${{ matrix.os }}-electron-${{ matrix.electronVersion }}.trx" --logger "console;verbosity=detailed" --results-directory test-results
+          dotnet test src/ElectronNET.IntegrationTests/ElectronNET.IntegrationTests.csproj -c Release --no-build -r ${{ matrix.rid }} -p:RuntimeIdentifier=${{ matrix.rid }} -p:ElectronVersion=${{ matrix.electronVersion }} --logger "trx;LogFileName=${{ matrix.os }}-electron-${{ matrix.electronVersion }}.trx" --logger "console;verbosity=detailed" --blame-hang --blame-hang-timeout 5min --results-directory test-results
 
       - name: Upload raw test results
         if: always()
@@ -114,6 +112,7 @@ jobs:
     runs-on: ubuntu-24.04
     if: always()
     needs: [tests]
+    timeout-minutes: 10
 
     permissions:
       actions: read


### PR DESCRIPTION
- Build and Publish now only triggers on push to main/develop (was: every push), so feature-branch pushes no longer run a second full matrix in parallel to PR Validation.

- integration-tests concurrency group is now scoped per calling workflow (github.workflow + github.ref), preventing PR Validation and Build and Publish from canceling each other's reusable test runs.

- Added timeout-minutes (25 per matrix job, 15 per dotnet test step, 10 for summary job) so a hung Electron process no longer keeps a runner busy until the 6h default timeout, which previously required manual cancel.

- Added --blame-hang --blame-hang-timeout 5min to dotnet test so hung tests produce a dump and fail fast instead of stalling.

- Removed pointless 0-20s random sleep step at the start of every matrix job.