### PR TITLE
Add Overloads for `UseElectron`

### DIFF
--- a/src/ElectronNET.API/ElectronNetRuntime.cs
+++ b/src/ElectronNET.API/ElectronNetRuntime.cs
@@ -50,8 +50,6 @@
 
         internal static int? ElectronProcessId { get; set; }
 
-        internal static Func<Task> OnAppReadyCallback { get; set; }
-
         internal static ISocketConnection GetSocket()
         {
             return RuntimeControllerCore?.Socket;

--- a/src/ElectronNET.AspNet/API/WebApplicationBuilderExtensions.cs
+++ b/src/ElectronNET.AspNet/API/WebApplicationBuilderExtensions.cs
@@ -44,5 +44,98 @@
 
             return builder;
         }
+
+        /// <summary>
+        /// Adds Electron.NET support to the current ASP.NET Core application and registers an application-ready callback.
+        /// </summary>
+        /// <param name="builder">The <see cref="WebApplicationBuilder"/> to extend.</param>
+        /// <param name="args">The command-line arguments passed to the process, forwarded to Electron.</param>
+        /// <param name="onAppReadyCallback">
+        /// An asynchronous callback invoked when the Electron app is ready. Use this to create windows or perform initialization.
+        /// </param>
+        /// <returns>
+        /// The same <see cref="WebApplicationBuilder"/> instance to enable fluent configuration.
+        /// </returns>
+        /// <example>
+        /// <code language="csharp">
+        /// var builder = WebApplication.CreateBuilder(args)
+        ///     .UseElectron(args, async (processArgs) =>
+        ///     {
+        ///         // Create the main browser window or perform other startup tasks.
+        ///     });
+        ///
+        /// var app = builder.Build();
+        /// app.MapRazorPages();
+        /// app.Run();
+        /// </code>
+        /// </example>
+        public static WebApplicationBuilder UseElectron(this WebApplicationBuilder builder, string[] args, Func<string[], Task> onAppReadyCallback)
+        {
+            builder.WebHost.UseElectron(args, onAppReadyCallback);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds Electron.NET support to the current ASP.NET Core application and registers an application-ready callback.
+        /// </summary>
+        /// <param name="builder">The <see cref="WebApplicationBuilder"/> to extend.</param>
+        /// <param name="args">The command-line arguments passed to the process, forwarded to Electron.</param>
+        /// <param name="onAppReadyCallback">
+        /// An asynchronous callback invoked when the Electron app is ready. Use this to create windows or perform initialization.
+        /// </param>
+        /// <returns>
+        /// The same <see cref="WebApplicationBuilder"/> instance to enable fluent configuration.
+        /// </returns>
+        /// <example>
+        /// <code language="csharp">
+        /// var builder = WebApplication.CreateBuilder(args)
+        ///     .UseElectron(args, async (serviceProvider) =>
+        ///     {
+        ///         // Create the main browser window or perform other startup tasks.
+        ///     });
+        ///
+        /// var app = builder.Build();
+        /// app.MapRazorPages();
+        /// app.Run();
+        /// </code>
+        /// </example>
+        public static WebApplicationBuilder UseElectron(this WebApplicationBuilder builder, string[] args, Func<IServiceProvider, Task> onAppReadyCallback)
+        {
+            builder.WebHost.UseElectron(args, onAppReadyCallback);
+
+            return builder;
+        }
+
+        /// <summary>
+        /// Adds Electron.NET support to the current ASP.NET Core application and registers an application-ready callback.
+        /// </summary>
+        /// <param name="builder">The <see cref="WebApplicationBuilder"/> to extend.</param>
+        /// <param name="args">The command-line arguments passed to the process, forwarded to Electron.</param>
+        /// <param name="onAppReadyCallback">
+        /// An asynchronous callback invoked when the Electron app is ready. Use this to create windows or perform initialization.
+        /// </param>
+        /// <returns>
+        /// The same <see cref="WebApplicationBuilder"/> instance to enable fluent configuration.
+        /// </returns>
+        /// <example>
+        /// <code language="csharp">
+        /// var builder = WebApplication.CreateBuilder(args)
+        ///     .UseElectron(args, async (serviceProvider, processArgs) =>
+        ///     {
+        ///         // Create the main browser window or perform other startup tasks.
+        ///     });
+        ///
+        /// var app = builder.Build();
+        /// app.MapRazorPages();
+        /// app.Run();
+        /// </code>
+        /// </example>
+        public static WebApplicationBuilder UseElectron(this WebApplicationBuilder builder, string[] args, Func<IServiceProvider, string[], Task> onAppReadyCallback)
+        {
+            builder.WebHost.UseElectron(args, onAppReadyCallback);
+
+            return builder;
+        }
     }
 }

--- a/src/ElectronNET.AspNet/API/WebHostBuilderExtensions.cs
+++ b/src/ElectronNET.AspNet/API/WebHostBuilderExtensions.cs
@@ -61,8 +61,16 @@
         /// </example>
         public static IWebHostBuilder UseElectron(this IWebHostBuilder builder, string[] args, Func<Task> onAppReadyCallback)
         {
-            ElectronNetRuntime.OnAppReadyCallback = onAppReadyCallback;
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IAppReadyCallbackResolver>(_ => new AppReadyCallbackResolver(onAppReadyCallback));
+            });
 
+            return UseElectronCore(builder, args);
+        }
+
+        private static IWebHostBuilder UseElectronCore(IWebHostBuilder builder, string[] args)
+        {
             // no matter how this is set - let's unset to prevent Electron not starting as expected
             // e.g., VS Code sets this env variable, but this will cause `require("electron")` to not
             // work as expected, see issue #952

--- a/src/ElectronNET.AspNet/API/WebHostBuilderExtensions.cs
+++ b/src/ElectronNET.AspNet/API/WebHostBuilderExtensions.cs
@@ -69,6 +69,144 @@
             return UseElectronCore(builder, args);
         }
 
+        /// <summary>
+        /// Adds Electron.NET support to the current ASP.NET Core web host and registers an application-ready callback.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebHostBuilder"/> to extend.</param>
+        /// <param name="args">The command-line arguments passed to the process.</param>
+        /// <param name="onAppReadyCallback">
+        /// An asynchronous callback invoked when the Electron app is ready. Use this to create windows or perform initialization.
+        /// </param>
+        /// <returns>
+        /// The same <see cref="IWebHostBuilder"/> instance to enable fluent configuration.
+        /// </returns>
+        /// <example>
+        /// <code language="csharp">
+        /// using Microsoft.AspNetCore.Hosting;
+        /// using Microsoft.Extensions.Hosting;
+        /// using ElectronNET.API;
+        ///
+        /// public class Program
+        /// {
+        ///     public static void Main(string[] args)
+        ///     {
+        ///         Host.CreateDefaultBuilder(args)
+        ///             .ConfigureWebHostDefaults(webBuilder =>
+        ///             {
+        ///                 webBuilder.UseStartup&lt;Startup&gt;();
+        ///                 webBuilder.UseElectron(args, async (processArgs) =>
+        ///                 {
+        ///                     // Create the main browser window or perform other startup tasks.
+        ///                 });
+        ///             })
+        ///             .Build()
+        ///             .Run();
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        public static IWebHostBuilder UseElectron(this IWebHostBuilder builder, string[] args, Func<string[], Task> onAppReadyCallback)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IAppReadyCallbackResolver>(_ => new AppReadyCallbackResolver(args, onAppReadyCallback));
+            });
+
+            return UseElectronCore(builder, args);
+        }
+
+        /// <summary>
+        /// Adds Electron.NET support to the current ASP.NET Core web host and registers an application-ready callback.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebHostBuilder"/> to extend.</param>
+        /// <param name="args">The command-line arguments passed to the process.</param>
+        /// <param name="onAppReadyCallback">
+        /// An asynchronous callback invoked when the Electron app is ready. Use this to create windows or perform initialization.
+        /// </param>
+        /// <returns>
+        /// The same <see cref="IWebHostBuilder"/> instance to enable fluent configuration.
+        /// </returns>
+        /// <example>
+        /// <code language="csharp">
+        /// using Microsoft.AspNetCore.Hosting;
+        /// using Microsoft.Extensions.Hosting;
+        /// using ElectronNET.API;
+        ///
+        /// public class Program
+        /// {
+        ///     public static void Main(string[] args)
+        ///     {
+        ///         Host.CreateDefaultBuilder(args)
+        ///             .ConfigureWebHostDefaults(webBuilder =>
+        ///             {
+        ///                 webBuilder.UseStartup&lt;Startup&gt;();
+        ///                 webBuilder.UseElectron(args, async (serviceProvider) =>
+        ///                 {
+        ///                     // Create the main browser window or perform other startup tasks.
+        ///                 });
+        ///             })
+        ///             .Build()
+        ///             .Run();
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        public static IWebHostBuilder UseElectron(this IWebHostBuilder builder, string[] args, Func<IServiceProvider, Task> onAppReadyCallback)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IAppReadyCallbackResolver>(provider => new AppReadyCallbackResolver(provider, onAppReadyCallback));
+            });
+
+            return UseElectronCore(builder, args);
+        }
+
+        /// <summary>
+        /// Adds Electron.NET support to the current ASP.NET Core web host and registers an application-ready callback.
+        /// </summary>
+        /// <param name="builder">The <see cref="IWebHostBuilder"/> to extend.</param>
+        /// <param name="args">The command-line arguments passed to the process.</param>
+        /// <param name="onAppReadyCallback">
+        /// An asynchronous callback invoked when the Electron app is ready. Use this to create windows or perform initialization.
+        /// </param>
+        /// <returns>
+        /// The same <see cref="IWebHostBuilder"/> instance to enable fluent configuration.
+        /// </returns>
+        /// <example>
+        /// <code language="csharp">
+        /// using Microsoft.AspNetCore.Hosting;
+        /// using Microsoft.Extensions.Hosting;
+        /// using ElectronNET.API;
+        ///
+        /// public class Program
+        /// {
+        ///     public static void Main(string[] args)
+        ///     {
+        ///         Host.CreateDefaultBuilder(args)
+        ///             .ConfigureWebHostDefaults(webBuilder =>
+        ///             {
+        ///                 webBuilder.UseStartup&lt;Startup&gt;();
+        ///                 webBuilder.UseElectron(args, async (serviceProvider, processArgs) =>
+        ///                 {
+        ///                     // Create the main browser window or perform other startup tasks.
+        ///                 });
+        ///             })
+        ///             .Build()
+        ///             .Run();
+        ///     }
+        /// }
+        /// </code>
+        /// </example>
+        public static IWebHostBuilder UseElectron(this IWebHostBuilder builder, string[] args, Func<IServiceProvider, string[], Task> onAppReadyCallback)
+        {
+            builder.ConfigureServices(services =>
+            {
+                services.AddSingleton<IAppReadyCallbackResolver>(provider => new AppReadyCallbackResolver(provider, args, onAppReadyCallback));
+            });
+
+            return UseElectronCore(builder, args);
+        }
+
         private static IWebHostBuilder UseElectronCore(IWebHostBuilder builder, string[] args)
         {
             // no matter how this is set - let's unset to prevent Electron not starting as expected

--- a/src/ElectronNET.AspNet/Runtime/Controllers/RuntimeControllerAspNetBase.cs
+++ b/src/ElectronNET.AspNet/Runtime/Controllers/RuntimeControllerAspNetBase.cs
@@ -17,13 +17,15 @@
     {
         private readonly IServer server;
         private readonly AspNetLifetimeAdapter aspNetLifetimeAdapter;
+        private readonly IAppReadyCallbackResolver callbackResolver;
         private readonly IElectronAuthenticationService authenticationService;
         private SocketBridgeService socketBridge;
 
-        protected RuntimeControllerAspNetBase(IServer server, AspNetLifetimeAdapter aspNetLifetimeAdapter, IElectronAuthenticationService authenticationService = null)
+        protected RuntimeControllerAspNetBase(IServer server, AspNetLifetimeAdapter aspNetLifetimeAdapter, IAppReadyCallbackResolver callbackResolver, IElectronAuthenticationService authenticationService = null)
         {
             this.server = server;
             this.aspNetLifetimeAdapter = aspNetLifetimeAdapter;
+            this.callbackResolver = callbackResolver;
             this.authenticationService = authenticationService;
             this.aspNetLifetimeAdapter.Ready += this.AspNetLifetimeAdapter_Ready;
             this.aspNetLifetimeAdapter.Stopping += this.AspNetLifetimeAdapter_Stopping;
@@ -130,15 +132,15 @@
 
         private async Task RunReadyCallback()
         {
-            if (ElectronNetRuntime.OnAppReadyCallback == null)
+            if (!callbackResolver.HasCallback)
             {
-                Console.WriteLine("Warning: Non OnReadyCallback provided in UseElectron() setup.");
+                Console.WriteLine("Warning: No OnReadyCallback provided in UseElectron() setup.");
                 return;
             }
 
             try
             {
-                await ElectronNetRuntime.OnAppReadyCallback().ConfigureAwait(false);
+                await callbackResolver.Invoke().ConfigureAwait(false);
             }
             catch (Exception ex)
             {

--- a/src/ElectronNET.AspNet/Runtime/Controllers/RuntimeControllerAspNetDotnetFirst.cs
+++ b/src/ElectronNET.AspNet/Runtime/Controllers/RuntimeControllerAspNetDotnetFirst.cs
@@ -14,7 +14,7 @@
     {
         private ElectronProcessBase electronProcess;
 
-        public RuntimeControllerAspNetDotnetFirst(IServer server, AspNetLifetimeAdapter aspNetLifetimeAdapter, IElectronAuthenticationService authenticationService = null) : base(server, aspNetLifetimeAdapter, authenticationService)
+        public RuntimeControllerAspNetDotnetFirst(IServer server, AspNetLifetimeAdapter aspNetLifetimeAdapter, IAppReadyCallbackResolver callbackResolver, IElectronAuthenticationService authenticationService = null) : base(server, aspNetLifetimeAdapter, callbackResolver, authenticationService)
         {
         }
 

--- a/src/ElectronNET.AspNet/Runtime/Controllers/RuntimeControllerAspNetElectronFirst.cs
+++ b/src/ElectronNET.AspNet/Runtime/Controllers/RuntimeControllerAspNetElectronFirst.cs
@@ -11,7 +11,7 @@
     {
         private ElectronProcessBase electronProcess;
 
-        public RuntimeControllerAspNetElectronFirst(IServer server, AspNetLifetimeAdapter aspNetLifetimeAdapter, IElectronAuthenticationService authenticationService = null) : base(server, aspNetLifetimeAdapter, authenticationService)
+        public RuntimeControllerAspNetElectronFirst(IServer server, AspNetLifetimeAdapter aspNetLifetimeAdapter, IAppReadyCallbackResolver callbackResolver, IElectronAuthenticationService authenticationService = null) : base(server, aspNetLifetimeAdapter, callbackResolver, authenticationService)
         {
         }
 

--- a/src/ElectronNET.AspNet/Runtime/Services/AppReadyCallbackResolver.cs
+++ b/src/ElectronNET.AspNet/Runtime/Services/AppReadyCallbackResolver.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace ElectronNET.AspNet.Runtime
+{
+    internal class AppReadyCallbackResolver : IAppReadyCallbackResolver
+    {
+        private readonly Func<Task> _callback;
+
+        public AppReadyCallbackResolver()
+        { }
+
+        public AppReadyCallbackResolver(Func<Task> callback)
+        {
+            _callback = callback;
+        }
+
+        public AppReadyCallbackResolver(string[] args, Func<string[], Task> callback)
+        {
+            _callback = () => callback.Invoke(args);
+        }
+
+        public AppReadyCallbackResolver(IServiceProvider serviceProvider, Func<IServiceProvider, Task> callback)
+        {
+            _callback = () => callback.Invoke(serviceProvider);
+        }
+
+        public AppReadyCallbackResolver(IServiceProvider serviceProvider, string[] args, Func<IServiceProvider, string[], Task> callback)
+        {
+            _callback = () => callback.Invoke(serviceProvider, args);
+        }
+
+        public bool HasCallback => _callback != null;
+
+        public Task Invoke() => _callback?.Invoke() ?? Task.CompletedTask;
+    }
+}

--- a/src/ElectronNET.AspNet/Runtime/Services/AppReadyCallbackResolver.cs
+++ b/src/ElectronNET.AspNet/Runtime/Services/AppReadyCallbackResolver.cs
@@ -17,17 +17,26 @@ namespace ElectronNET.AspNet.Runtime
 
         public AppReadyCallbackResolver(string[] args, Func<string[], Task> callback)
         {
-            _callback = () => callback.Invoke(args);
+            if (callback != null)
+            {
+                _callback = () => callback.Invoke(args);
+            }
         }
 
         public AppReadyCallbackResolver(IServiceProvider serviceProvider, Func<IServiceProvider, Task> callback)
         {
-            _callback = () => callback.Invoke(serviceProvider);
+            if (callback != null)
+            {
+                _callback = () => callback.Invoke(serviceProvider);
+            }
         }
 
         public AppReadyCallbackResolver(IServiceProvider serviceProvider, string[] args, Func<IServiceProvider, string[], Task> callback)
         {
-            _callback = () => callback.Invoke(serviceProvider, args);
+            if (callback != null)
+            {
+                _callback = () => callback.Invoke(serviceProvider, args);
+            }
         }
 
         public bool HasCallback => _callback != null;

--- a/src/ElectronNET.AspNet/Runtime/Services/IAppReadyCallbackResolver.cs
+++ b/src/ElectronNET.AspNet/Runtime/Services/IAppReadyCallbackResolver.cs
@@ -1,0 +1,11 @@
+﻿using System.Threading.Tasks;
+
+namespace ElectronNET.AspNet.Runtime
+{
+    internal interface IAppReadyCallbackResolver
+    {
+        public bool HasCallback { get; }
+
+        public Task Invoke();
+    }
+}


### PR DESCRIPTION
Adds the new overloads proposed in #1076. Also replaces the previously static property with a resolver service.