### PR TITLE
fix(shore): bloated asar and corrupted packaged directory

### DIFF
--- a/src/ElectronNET.ConsoleApp/ElectronNET.ConsoleApp.csproj
+++ b/src/ElectronNET.ConsoleApp/ElectronNET.ConsoleApp.csproj
@@ -70,7 +70,7 @@
     <ProjectReference Include="..\ElectronNET.API\ElectronNET.API.csproj" Condition="$(ElectronNetDevMode)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ElectronNET.Core" Version="0.5.0" Condition="'$(ElectronNetDevMode)' != 'true'" />
+    <PackageReference Include="ElectronNET.Core" Version="0.5.1" Condition="'$(ElectronNetDevMode)' != 'true'" />
   </ItemGroup>
 
   <Import Project="..\ElectronNET\build\ElectronNET.Core.targets" Condition="$(ElectronNetDevMode)" />

--- a/src/ElectronNET.IntegrationTests/ElectronNET.IntegrationTests.csproj
+++ b/src/ElectronNET.IntegrationTests/ElectronNET.IntegrationTests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <!-- When this is enabled, the project will be switched from nuget packages to consuming the ElectronNet orchestration directly -->
     <ElectronNetDevMode>true</ElectronNetDevMode>
+      <IsTest>True</IsTest>
   </PropertyGroup>
 
   <Import Project="..\ElectronNET\build\ElectronNET.Core.props" Condition="$(ElectronNetDevMode)" />

--- a/src/ElectronNET.Samples.AuthMiddleware/Components/App.razor
+++ b/src/ElectronNET.Samples.AuthMiddleware/Components/App.razor
@@ -8,7 +8,7 @@
     <ResourcePreloader />
     <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]" />
     <link rel="stylesheet" href="@Assets["app.css"]" />
-    <link rel="stylesheet" href="@Assets["electronnet-samples-blazorsignalr.styles.css"]" />
+    <link rel="stylesheet" href="@Assets["electronnet-samples-authmiddleware.styles.css"]" />
     <ImportMap />
     <link rel="icon" type="image/png" href="favicon.png" />
     <HeadOutlet />

--- a/src/ElectronNET.Samples.AuthMiddleware/Components/Layout/NavMenu.razor
+++ b/src/ElectronNET.Samples.AuthMiddleware/Components/Layout/NavMenu.razor
@@ -1,6 +1,6 @@
 ﻿<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
-        <a class="navbar-brand" href="">ElectronNET.Samples.BlazorSignalR</a>
+        <a class="navbar-brand" href="">ElectronNET.Samples.AuthMiddleware</a>
     </div>
 </div>
 

--- a/src/ElectronNET.Samples.ElectronHostHook/ElectronNET.Samples.ElectronHostHook.csproj
+++ b/src/ElectronNET.Samples.ElectronHostHook/ElectronNET.Samples.ElectronHostHook.csproj
@@ -27,8 +27,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="ElectronNET.Core" Version="0.5.0" Condition="'$(ElectronNetDevMode)' != 'true'" />
-    <PackageReference Include="ElectronNET.Core.AspNet" Version="0.5.0" Condition="'$(ElectronNetDevMode)' != 'true'" />
+    <PackageReference Include="ElectronNET.Core" Version="0.5.1" Condition="'$(ElectronNetDevMode)' != 'true'" />
+    <PackageReference Include="ElectronNET.Core.AspNet" Version="0.5.1" Condition="'$(ElectronNetDevMode)' != 'true'" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.9.3" />
   </ItemGroup>
 

--- a/src/ElectronNET.Samples.ElectronHostHook/ElectronNET.Samples.ElectronHostHook.csproj
+++ b/src/ElectronNET.Samples.ElectronHostHook/ElectronNET.Samples.ElectronHostHook.csproj
@@ -14,7 +14,7 @@
     <TypeScriptUseNodeJS>true</TypeScriptUseNodeJS>
     <TypeScriptTSConfig>ElectronHostHook/tsconfig.json</TypeScriptTSConfig>
     <TypeScriptCompileOnSaveEnabled>true</TypeScriptCompileOnSaveEnabled>
-    <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
+    <TypeScriptCompileBlocked>false</TypeScriptCompileBlocked>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ElectronNET.WebApp/ElectronNET.WebApp.csproj
+++ b/src/ElectronNET.WebApp/ElectronNET.WebApp.csproj
@@ -76,8 +76,8 @@
     <ProjectReference Include="..\ElectronNET.AspNet\ElectronNET.AspNet.csproj" Condition="$(ElectronNetDevMode)" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ElectronNET.Core" Version="0.5.0" Condition="'$(ElectronNetDevMode)' != 'true'" />
-    <PackageReference Include="ElectronNET.Core.AspNet" Version="0.5.0" Condition="'$(ElectronNetDevMode)' != 'true'" />
+    <PackageReference Include="ElectronNET.Core" Version="0.5.1" Condition="'$(ElectronNetDevMode)' != 'true'" />
+    <PackageReference Include="ElectronNET.Core.AspNet" Version="0.5.1" Condition="'$(ElectronNetDevMode)' != 'true'" />
     <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.9.3" />
   </ItemGroup>
 

--- a/src/ElectronNET/build/ElectronNET.LateImport.targets
+++ b/src/ElectronNET/build/ElectronNET.LateImport.targets
@@ -177,9 +177,12 @@
     </PropertyGroup>
 
     <ItemGroup>
+      <!-- tsconfig.json is a build-time config, not a runtime file. Excluding it also stops
+           Microsoft.TypeScript.MSBuild from discovering and compiling the host's tsconfig
+           (types:["node"]) in the consumer project when hook TypeScript compilation is enabled. -->
       <ElectronSourceFiles
         Include="$(ElectronSourceFilesPath)\**\*.js;$(ElectronSourceFilesPath)\**\*.json;$(ElectronSourceFilesPath)\**\*.html"
-        Exclude="$(ElectronSourceFilesPath)\**\build-helper.js" />
+        Exclude="$(ElectronSourceFilesPath)\**\build-helper.js;$(ElectronSourceFilesPath)\**\tsconfig.json" />
     </ItemGroup>
 
     <ItemGroup>
@@ -213,12 +216,15 @@
       </ElectronCustomHookPackageJson>
     </ItemGroup>
 
-    <!-- A custom host hook's TypeScript is not recompiled during a CLI build, so the committed
-         ElectronHostHook JavaScript (and source maps) must be packaged as-is. Reclassify them
-         from None into .electron\ElectronHostHook content (mirroring ElectronSourceFiles) so they
-         are copied to the build output and, at publish, swept into app\ -> app.asar. Without this
-         require('electron-host-hook') fails at runtime ('Cannot find module .../index.js'). -->
-    <ItemGroup Condition="'$(ElectronHasCustomHookCode)' == 'true'">
+    <!-- Committed-JS mode (TypeScriptCompileBlocked=true): the hook TypeScript is not compiled
+         during the build, so the committed ElectronHostHook JavaScript (and source maps) are
+         packaged as-is. Reclassify them from None into .electron\ElectronHostHook content
+         (mirroring ElectronSourceFiles) so they reach the build output and, at publish, are swept
+         into app\ -> app.asar. When compilation is enabled (TypeScriptCompileBlocked!=true) this
+         is skipped: Microsoft.TypeScript.MSBuild compiles the hook and ElectronAdjustHostHookOutput
+         routes the output, so reclassifying would duplicate .electron\ElectronHostHook items.
+         Without one of these, require('electron-host-hook') fails ('Cannot find module .../index.js'). -->
+    <ItemGroup Condition="'$(ElectronHasCustomHookCode)' == 'true' AND '$(TypeScriptCompileBlocked)' == 'true'">
       <None Remove="ElectronHostHook\**\*.js;ElectronHostHook\**\*.js.map" />
       <ElectronCustomHookJsFiles Include="ElectronHostHook\**\*.js;ElectronHostHook\**\*.js.map"
                                  Exclude="ElectronHostHook\node_modules\**" />
@@ -229,11 +235,11 @@
     </ItemGroup>
 
     <AssignTargetPath Files="@(ElectronCustomHookJsFiles)" RootFolder="$(MSBuildProjectDirectory)"
-                      Condition="'$(ElectronHasCustomHookCode)' == 'true'">
+                      Condition="'$(ElectronHasCustomHookCode)' == 'true' AND '$(TypeScriptCompileBlocked)' == 'true'">
       <Output TaskParameter="AssignedFiles" ItemName="ElectronCustomHookJsFilesWithTargetPath" />
     </AssignTargetPath>
 
-    <ItemGroup Condition="'$(ElectronHasCustomHookCode)' == 'true'">
+    <ItemGroup Condition="'$(ElectronHasCustomHookCode)' == 'true' AND '$(TypeScriptCompileBlocked)' == 'true'">
       <FilesForPackagingFromProject Include="@(ElectronCustomHookJsFilesWithTargetPath->'%(Identity)')" />
       <ContentWithTargetPath Include="@(ElectronCustomHookJsFilesWithTargetPath->'%(Identity)')" />
       <Content Include="@(ElectronCustomHookJsFiles->'%(Identity)')" />
@@ -257,13 +263,45 @@
   </Target>
 
 
+  <!-- When hook TypeScript compilation is enabled (TypeScriptCompileBlocked!=true), restore the
+       hook's npm dependencies into ElectronHostHook\node_modules before tsc runs so its imports
+       (e.g. socket.io) resolve. Incremental: only re-runs when the hook package.json changes or
+       node_modules is missing. Skipped in committed-JS mode and at design time. -->
+  <Target Name="ElectronRestoreHostHookDependencies"
+          BeforeTargets="CompileTypeScriptWithTSConfig;CompileTypeScript"
+          Condition="'@(ElectronCustomHookTsFiles->Count())' &gt; 1 AND Exists('$(MSBuildProjectDirectory)\ElectronHostHook\package.json') AND '$(TypeScriptCompileBlocked)' != 'true' AND '$(DesignTimeBuild)' != 'true'"
+          Inputs="$(MSBuildProjectDirectory)\ElectronHostHook\package.json"
+          Outputs="$(MSBuildProjectDirectory)\ElectronHostHook\node_modules\.package-lock.json">
+
+    <PropertyGroup>
+      <IsLinuxWsl>false</IsLinuxWsl>
+      <IsLinuxWsl Condition="'$(ElectronPlatform)' == 'linux' AND $([MSBuild]::IsOSPlatform('Windows'))">true</IsLinuxWsl>
+      <_NpmCmd>npm install</_NpmCmd>
+      <_NpmCmd Condition="'$(IsLinuxWsl)' == 'true'">wsl bash -ic '$(_NpmCmd)'</_NpmCmd>
+    </PropertyGroup>
+
+    <Message Importance="High" Text="Restoring ElectronHostHook npm dependencies for TypeScript compilation..." />
+
+    <Exec Command="$(_NpmCmd)"
+          WorkingDirectory="$([System.IO.Path]::Combine('$(MSBuildProjectDirectory)', 'ElectronHostHook'))"
+          Timeout="600000" StandardOutputImportance="Low" StandardErrorImportance="High" ContinueOnError="false" />
+  </Target>
+
+
   <!-- Run before GetTypeScriptOutputForPublishing to adjust the target directory -->
   <Target Name="ElectronAdjustHostHookOutput" BeforeTargets="GetTypeScriptOutputForPublishing" DependsOnTargets="CompileTypeScriptWithTSConfig">
 
     <ItemGroup>
+      <!-- Route the compiled hook JS to .electron\ElectronHostHook. Do NOT reuse
+           %(DestinationRelativePath): with no outDir in the hook tsconfig, VsTsc leaves it as
+           an absolute path, which would produce .electron\<absolute-path>. Derive the target
+           from the file name instead (hook files are flat). Link is set because
+           GetTypeScriptOutputForPublishing re-runs AssignTargetPath, which honors Link for the
+           publish TargetPath. -->
       <GeneratedJavascript Update="@(GeneratedJavascript)">
-        <DestinationRelativePath>$(ElectronDirName)\%(DestinationRelativePath)</DestinationRelativePath>
-        <TargetPath>$(ElectronDirName)\%(DestinationRelativePath)</TargetPath>
+        <DestinationRelativePath>$(ElectronDirName)\ElectronHostHook\%(Filename)%(Extension)</DestinationRelativePath>
+        <TargetPath>$(ElectronDirName)\ElectronHostHook\%(Filename)%(Extension)</TargetPath>
+        <Link>$(ElectronDirName)\ElectronHostHook\%(Filename)%(Extension)</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </GeneratedJavascript>
     </ItemGroup>

--- a/src/ElectronNET/build/ElectronNET.LateImport.targets
+++ b/src/ElectronNET/build/ElectronNET.LateImport.targets
@@ -213,6 +213,32 @@
       </ElectronCustomHookPackageJson>
     </ItemGroup>
 
+    <!-- A custom host hook's TypeScript is not recompiled during a CLI build, so the committed
+         ElectronHostHook JavaScript (and source maps) must be packaged as-is. Reclassify them
+         from None into .electron\ElectronHostHook content (mirroring ElectronSourceFiles) so they
+         are copied to the build output and, at publish, swept into app\ -> app.asar. Without this
+         require('electron-host-hook') fails at runtime ('Cannot find module .../index.js'). -->
+    <ItemGroup Condition="'$(ElectronHasCustomHookCode)' == 'true'">
+      <None Remove="ElectronHostHook\**\*.js;ElectronHostHook\**\*.js.map" />
+      <ElectronCustomHookJsFiles Include="ElectronHostHook\**\*.js;ElectronHostHook\**\*.js.map"
+                                 Exclude="ElectronHostHook\node_modules\**" />
+      <ElectronCustomHookJsFiles Update="@(ElectronCustomHookJsFiles)">
+        <Link>$(ElectronDirName)\ElectronHostHook\%(RecursiveDir)%(FileName)%(Extension)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </ElectronCustomHookJsFiles>
+    </ItemGroup>
+
+    <AssignTargetPath Files="@(ElectronCustomHookJsFiles)" RootFolder="$(MSBuildProjectDirectory)"
+                      Condition="'$(ElectronHasCustomHookCode)' == 'true'">
+      <Output TaskParameter="AssignedFiles" ItemName="ElectronCustomHookJsFilesWithTargetPath" />
+    </AssignTargetPath>
+
+    <ItemGroup Condition="'$(ElectronHasCustomHookCode)' == 'true'">
+      <FilesForPackagingFromProject Include="@(ElectronCustomHookJsFilesWithTargetPath->'%(Identity)')" />
+      <ContentWithTargetPath Include="@(ElectronCustomHookJsFilesWithTargetPath->'%(Identity)')" />
+      <Content Include="@(ElectronCustomHookJsFiles->'%(Identity)')" />
+    </ItemGroup>
+
     <ItemGroup>
       <ElectronIntermediatePackageJson Include="$(ElectronIntermediatePackageJson)" />
     </ItemGroup>
@@ -449,6 +475,10 @@
       <PublishDir>$(_OriginalPublishDir)</PublishDir>
       <PublishDir Condition="'$(_NonIntermediatePublishDir)' != ''">$(_NonIntermediatePublishDir)</PublishDir>
       <ElectronPublishDir>$(_OriginalPublishDir)</ElectronPublishDir>
+      <!-- The Electron host files (main.js, package.json, runtime node_modules, ...) are packed
+           into app.asar. They live in a dedicated 'app' subfolder so the .NET app in 'bin' is NOT
+           swept into the asar by electron-builder's default 'files' glob. See directories.app below. -->
+      <ElectronAppDir>$(ElectronPublishDir)app\</ElectronAppDir>
     </PropertyGroup>
 
 
@@ -489,7 +519,7 @@ For more information, see: https://github.com/ElectronNET/Electron.NET/wiki/Migr
 
     <ItemGroup>
       <ElectronPublishFilesToMove Update="@(ElectronPublishFilesToMove)" >
-        <MoveTargetPath>$(ElectronPublishDir)%(RecursiveDir)%(FileName)%(Extension)</MoveTargetPath>
+        <MoveTargetPath>$(ElectronAppDir)%(RecursiveDir)%(FileName)%(Extension)</MoveTargetPath>
       </ElectronPublishFilesToMove>
     </ItemGroup>
 
@@ -504,13 +534,54 @@ For more information, see: https://github.com/ElectronNET/Electron.NET/wiki/Migr
     </PropertyGroup>
 
     <PropertyGroup>
+      <ElectronAppDirFullPath>$([System.IO.Path]::GetFullPath('$(ElectronAppDir)'))</ElectronAppDirFullPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
       <IsLinuxWsl>false</IsLinuxWsl>
       <IsLinuxWsl Condition="'$(ElectronPlatform)' == 'linux' AND $([MSBuild]::IsOSPlatform('Windows'))">true</IsLinuxWsl>
-      <_NpmCmd>npm install electron-builder@$(ElectronBuilderVersion) --save-dev </_NpmCmd>
-      <_NpmCmd Condition="'$(IsLinuxWsl)' == 'true'">wsl bash -ic '$(_NpmCmd)'</_NpmCmd>
     </PropertyGroup>
 
     <Message Importance="High" Text="ElectronPublishApp: ElectronPublishDirFullPath - $(ElectronPublishDirFullPath)" />
+    <Message Importance="High" Text="ElectronPublishApp: ElectronAppDirFullPath - $(ElectronAppDirFullPath)" />
+
+    <!-- Install the app's runtime (prod) dependencies into app\node_modules so they end up
+         inside app.asar. devDependencies (electron, eslint, typescript) are not needed here:
+         TypeScript is already compiled at build time and electron-builder fetches Electron itself. -->
+    <PropertyGroup>
+      <_NpmAppDepsCmd>npm install --omit=dev</_NpmAppDepsCmd>
+      <_NpmAppDepsCmd Condition="'$(IsLinuxWsl)' == 'true'">wsl bash -ic '$(_NpmAppDepsCmd)'</_NpmAppDepsCmd>
+    </PropertyGroup>
+
+    <Exec Command="$(_NpmAppDepsCmd)" WorkingDirectory="$(ElectronAppDirFullPath)" Timeout="600000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="@(CopiedFiles->Count()) > 0">
+      <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
+    </Exec>
+
+    <Message Importance="High" Text="Electron app dependency install failed!" Condition="'$(ExecExitCode)' != '0'" />
+
+    <!-- Install electron-builder (the dev tool) into the publish root, which is the
+         electron-builder projectDir (cwd). app metadata + runtime deps are read from
+         app\ via directories.app (standard electron-builder two-package.json layout).
+         Render the dev package.json first: the two-package.json layout requires a
+         package.json at the projectDir, and electron-builder requires the 'build'
+         configuration to live in this development package.json (it is rejected in the
+         application package.json under app\). The .NET app's metadata/version come from
+         app\package.json instead. -->
+    <ItemGroup>
+      <DevTemplateProperty Include="ElectronPackageId" Value="$(ElectronPackageId)" />
+      <DevTemplateProperty Include="Title" Value="$(Title)" />
+      <DevTemplateProperty Include="Version" Value="$(Version)" />
+    </ItemGroup>
+
+    <ReplaceTemplateTask TemplateFile="$(MSBuildThisFileDirectory)package.dev.template.json"
+                         OutputFile="$([System.IO.Path]::Combine('$(ElectronPublishDirFullPath)', 'package.json'))"
+                         TemplateProperties="@(DevTemplateProperty)"
+                         Condition="@(CopiedFiles->Count()) > 0" />
+
+    <PropertyGroup>
+      <_NpmCmd>npm install electron-builder@$(ElectronBuilderVersion)</_NpmCmd>
+      <_NpmCmd Condition="'$(IsLinuxWsl)' == 'true'">wsl bash -ic '$(_NpmCmd)'</_NpmCmd>
+    </PropertyGroup>
 
     <Exec Command="$(_NpmCmd)" WorkingDirectory="$(ElectronPublishDirFullPath)" Timeout="600000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="@(CopiedFiles->Count()) > 0">
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
@@ -529,6 +600,10 @@ For more information, see: https://github.com/ElectronNET/Electron.NET/wiki/Migr
       <ElectronPaParams Condition="'$(Version)' != ''">$(ElectronPaParams) -c.buildVersion &quot;$(Version)&quot;</ElectronPaParams>
       <ElectronPaParams Condition="'$(Copyright)' != ''">$(ElectronPaParams) -c.copyright &quot;$(Copyright)&quot;</ElectronPaParams>
       <ElectronPaParams>$(ElectronPaParams) -c.extraResources &quot;bin/**/*&quot;</ElectronPaParams>
+      <!-- Build app.asar from the 'app' subfolder only (host JS + runtime node_modules),
+           keeping the .NET app under 'bin' out of the asar. cwd stays the publish root so
+           extraResources and user icon paths under bin/ still resolve. -->
+      <ElectronPaParams>$(ElectronPaParams) -c.directories.app &quot;app&quot;</ElectronPaParams>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/ElectronNET/build/package.dev.template.json
+++ b/src/ElectronNET/build/package.dev.template.json
@@ -1,0 +1,19 @@
+{
+  "name": "electron-builder-host",
+  "version": "$(Version)",
+  "private": true,
+  "build": {
+    "appId": "$(ElectronPackageId)",
+    "linux": {
+      "desktop": {
+        "entry": { "Name": "$(Title)" }
+      },
+      "executableName": "$(ElectronPackageId)"
+    },
+    "deb": {
+      "desktop": {
+        "entry": { "Name": "$(Title)" }
+      }
+    }
+  }
+}

--- a/src/ElectronNET/build/package.template.json
+++ b/src/ElectronNET/build/package.template.json
@@ -1,20 +1,6 @@
 {
   "name": "$(ElectronPackageId)",
   "productName": "$(ElectronTitle)",
-  "build": {
-    "appId": "$(ElectronPackageId)",
-    "linux": {
-      "desktop": {
-        "entry": { "Name": "$(Title)" }
-      },
-      "executableName": "$(ElectronPackageId)"
-    },
-    "deb": {
-      "desktop": {
-        "entry": { "Name": "$(Title)" }
-      }
-    }
-  },
   "description": "$(Description)",
   "version": "$(Version)",
   "main": "main.js",


### PR DESCRIPTION
* Fix #1058 asar packaging issues by splitting node vs dotnet staging output in bin output dir
* Fix not anymore working examples
* Bump self dependencies to latest 0.5.1

Assisted-By: Claude:claude-4.8-opus