### PR TITLE
chore: use default sdk runtime identifier

### DIFF
--- a/src/ElectronNET/build/ElectronNET.Core.props
+++ b/src/ElectronNET/build/ElectronNET.Core.props
@@ -6,7 +6,7 @@
     <ElectronBuilderVersion>26.0</ElectronBuilderVersion>
     <!-- Default to the host SDK's RID (e.g. linux-x64, win-x64, osx-arm64) when none is passed,
          so `dotnet build/publish` without -r targets the current OS. -->
-    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$([System.Runtime.InteropServices.RuntimeInformation]::RuntimeIdentifier)</RuntimeIdentifier>
     <ElectronSingleInstance>true</ElectronSingleInstance>
     <ElectronSplashScreen></ElectronSplashScreen>
     <ElectronIcon></ElectronIcon>

--- a/src/ElectronNET/build/ElectronNET.Core.props
+++ b/src/ElectronNET/build/ElectronNET.Core.props
@@ -4,7 +4,9 @@
   <PropertyGroup Label="ElectronNetCommon">
     <ElectronVersion>30.4.0</ElectronVersion>
     <ElectronBuilderVersion>26.0</ElectronBuilderVersion>
-    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">win-x64</RuntimeIdentifier>
+    <!-- Default to the host SDK's RID (e.g. linux-x64, win-x64, osx-arm64) when none is passed,
+         so `dotnet build/publish` without -r targets the current OS. -->
+    <RuntimeIdentifier Condition="'$(RuntimeIdentifier)' == ''">$(NETCoreSdkRuntimeIdentifier)</RuntimeIdentifier>
     <ElectronSingleInstance>true</ElectronSingleInstance>
     <ElectronSplashScreen></ElectronSplashScreen>
     <ElectronIcon></ElectronIcon>


### PR DESCRIPTION
* Evaluate current runtime identifier by using msbuild property function of interop services RuntimeInformation instead of fixed value.

Assisted-By: Claude:claude-5-sonnet