### PR TITLE
Bug/#1091 - Fix CA1416 on AspNet project

### DIFF
--- a/src/ElectronNET.AspNet/ElectronNET.AspNet.csproj
+++ b/src/ElectronNET.AspNet/ElectronNET.AspNet.csproj
@@ -13,23 +13,6 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <Nullable>disable</Nullable>
     <RootNamespace>ElectronNET</RootNamespace>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net6.0|AnyCPU'">
-    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net8.0|AnyCPU'">
-    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0|AnyCPU'">
-    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net6.0|AnyCPU'">
-    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0|AnyCPU'">
-    <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net10.0|AnyCPU'">
     <NoWarn>1701;1702;4014;CS4014;CA1416;CS1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
- Avoid CA1416 error with the CLI during release build.
- Removed CA1416 platform compatibility warning from .editorconfig and all .csproj files, reverting to default handling.
- Eliminating redundant conditions and only suppressing specified warnings (excluding CA1416).