### PR TITLE
Add DotNet-First packaging layout support and build extensibility

### DIFF
--- a/src/ElectronNET.API/Common/ProcessRunner.cs
+++ b/src/ElectronNET.API/Common/ProcessRunner.cs
@@ -499,7 +499,7 @@
             try
             {
                 // This shouldn't throw here, but the mono process implementation doesn't always behave as it should.
-                this.process.WaitForExit();
+                this.process.WaitForExit(1000);
             }
             catch (Exception ex)
             {

--- a/src/ElectronNET.API/Runtime/Helpers/UnpackagedDetector.cs
+++ b/src/ElectronNET.API/Runtime/Helpers/UnpackagedDetector.cs
@@ -64,11 +64,20 @@
         private static bool? CheckUnpackaged2()
         {
             var dir = new DirectoryInfo(AppDomain.CurrentDomain.BaseDirectory);
+
+            // Electron-First packaging mode: the .NET binary is in resources/bin.
             if (dir.Name == "bin" && dir.Parent?.Name == "resources")
             {
                 return false;
             }
 
+            // DotNet-First packaging mode: the Electron host is in the electron subdirectory.
+            if (dir.GetDirectories().Any(e => e.Name == "electron"))
+            {
+                return false;
+            }
+
+            // Development mode: the .electron subdirectory exists.
             if (dir.GetDirectories().Any(e => e.Name == ".electron"))
             {
                 return true;

--- a/src/ElectronNET.API/Runtime/Services/ElectronProcess/ElectronProcessActive.cs
+++ b/src/ElectronNET.API/Runtime/Services/ElectronProcess/ElectronProcessActive.cs
@@ -87,10 +87,24 @@
             }
             else
             {
-                dir = dir.Parent!.Parent!;
-                startCmd = Path.Combine(dir.FullName, this.electronBinaryName);
+                // DotNet-First packaging mode: the Electron host is in the electron subdirectory.
+                var electronDir = Path.Combine(dir.FullName, "electron");
+
+                if (Directory.Exists(electronDir))
+                {
+                    // New DotNet-First directory layout.
+                    startCmd = Path.Combine(electronDir, this.electronBinaryName);
+                    workingDir = electronDir;
+                }
+                else
+                {
+                    // Fallback to the legacy Electron-First directory layout.
+                    dir = dir.Parent!.Parent!;
+                    startCmd = Path.Combine(dir.FullName, this.electronBinaryName);
+                    workingDir = dir.FullName;
+                }
+
                 args = $"-dotnetpacked -electronforcedport={this.socketPort:D} " + this.extraArguments;
-                workingDir = dir.FullName;
             }
 
             // We don't await this in order to let the state transition to "Starting"

--- a/src/ElectronNET/build/ElectronNET.Core.props
+++ b/src/ElectronNET/build/ElectronNET.Core.props
@@ -14,9 +14,9 @@
     <ElectronSplashScreen></ElectronSplashScreen>
     <ElectronIcon></ElectronIcon>
     <PackageIcon></PackageIcon>
-    <ElectronPackageId>$(MSBuildProjectName.Replace(".", "-").ToLower())</ElectronPackageId>
+    <ElectronPackageId Condition="'$(ElectronPackageId)' == ''">$(MSBuildProjectName.Replace(".", "-").ToLower())</ElectronPackageId>
     <ElectronBuilderJson>electron-builder.json</ElectronBuilderJson>
-    <Title>$(MSBuildProjectName)</Title>
+    <Title Condition="'$(Title)' == ''">$(MSBuildProjectName)</Title>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/src/ElectronNET/build/ElectronNET.LateImport.targets
+++ b/src/ElectronNET/build/ElectronNET.LateImport.targets
@@ -450,13 +450,11 @@
 
     <!--<Message Importance="High" Text="ElectronConfigureApp: CopiedFiles - @(_CopiedFiles)" />-->
 
-    <Message Importance="High" Text="Running command: $(_NpmCmd) in folder:  $(ElectronOutputPath)" Condition="@(_CopiedFiles->Count()) > 0" />
+    <Message Importance="High" Text="Running command: $(_NpmCmd) in folder:  $(ElectronOutputPath)" Condition="'$(ElectronSkipExecCommands)' != 'true' AND @(_CopiedFiles->Count()) > 0" />
 
     <Exec Command="$(_NpmCmd)" WorkingDirectory="$(ElectronOutputPath)" Timeout="600000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="'$(ElectronSkipExecCommands)' != 'true' AND @(_CopiedFiles->Count()) > 0">
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
     </Exec>
-
-    <Message Importance="High" Text="Electron setup failed!" Condition="'$(ExecExitCode)' != '0'" />
 
     <PropertyGroup>
       <_NpmCmd>node node_modules/electron/install.js</_NpmCmd>
@@ -465,13 +463,11 @@
       <_NpmCmd Condition="'$(IsLinuxWsl)' == 'true'">wsl bash -ic '$(_NpmCmd)'</_NpmCmd>
     </PropertyGroup>
 
-    <Message Importance="High" Text="Running command: $(_NpmCmd) in folder:  $(ElectronOutputPath)" Condition="$(ElectronMajor) &gt;= 42 AND @(_CopiedFiles->Count()) > 0" />
+    <Message Importance="High" Text="Running command: $(_NpmCmd) in folder:  $(ElectronOutputPath)" Condition="'$(ElectronSkipExecCommands)' != 'true' AND $(ElectronMajor) &gt;= 42 AND @(_CopiedFiles->Count()) > 0" />
 
-    <Exec Command="$(_NpmCmd)" WorkingDirectory="$(ElectronOutputPath)" Timeout="600000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="$(ElectronMajor) &gt;= 42 AND @(_CopiedFiles->Count()) > 0">
+    <Exec Command="$(_NpmCmd)" WorkingDirectory="$(ElectronOutputPath)" Timeout="1800000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="'$(ElectronSkipExecCommands)' != 'true' AND $(ElectronMajor) &gt;= 42 AND @(_CopiedFiles->Count()) > 0">
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
     </Exec>
-
-    <Message Importance="High" Text="Electron installation failed!" Condition="'$(ExecExitCode)' != '0'" />
 
     <!-- Fix up incorrect symlinks created by npm on Windows when targeting macOS -->
     <PropertyGroup>
@@ -610,8 +606,6 @@ For more information, see: https://github.com/ElectronNET/Electron.NET/wiki/Migr
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
     </Exec>
 
-    <Message Importance="High" Text="Electron app dependency install failed!" Condition="'$(ExecExitCode)' != '0'" />
-
     <!-- Install electron-builder (the dev tool) into the publish root, which is the
          electron-builder projectDir (cwd). app metadata + runtime deps are read from
          app\ via directories.app (standard electron-builder two-package.json layout).
@@ -640,8 +634,6 @@ For more information, see: https://github.com/ElectronNET/Electron.NET/wiki/Migr
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
     </Exec>
 
-    <Message Importance="High" Text="Electron setup failed!" Condition="'$(ExecExitCode)' != '0'" />
-
     <!-- Transform ElectronPublishUrlFullPath to a wslpath if IsLinuxWsl is true -->
     <Exec Command="wsl wslpath '$(ElectronPublishUrlFullPath)'" ConsoleToMsBuild="true" Condition="'$(IsLinuxWsl)' == 'true'">
       <Output TaskParameter="ConsoleOutput" PropertyName="ElectronPublishUrlFullPath" />
@@ -668,7 +660,6 @@ For more information, see: https://github.com/ElectronNET/Electron.NET/wiki/Migr
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
     </Exec>
 
-    <Message Importance="High" Text="Electron setup failed!" Condition="'$(ExecExitCode)' != '0'" />
 
   </Target>
 

--- a/src/ElectronNET/build/ElectronNET.LateImport.targets
+++ b/src/ElectronNET/build/ElectronNET.LateImport.targets
@@ -39,6 +39,11 @@
     <ElectronCustomHookTsFiles Include="ElectronHostHook\*.ts" />
   </ItemGroup>
 
+  <!-- Skip Exec commands configuration (default: false) -->
+  <PropertyGroup>
+    <ElectronSkipExecCommands Condition="'$(ElectronSkipExecCommands)' == ''">false</ElectronSkipExecCommands>
+  </PropertyGroup>
+
   <!-- Create variables for our output paths -->
   <PropertyGroup>
     <ElectronSourceFilesPath>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)\..\..\ElectronNET.Host'))</ElectronSourceFilesPath>
@@ -151,10 +156,12 @@
           BeforeTargets="AssignTargetPaths"
           DependsOnTargets="ElectronResolvePaths">
 
+    <!-- ElectronPublishDir allows overriding the intermediate publish directory -->
     <PropertyGroup Condition="'$(UsingMicrosoftNETSdkWeb)' != 'true'">
       <_NonIntermediatePublishDir>$(PublishDir)</_NonIntermediatePublishDir>
       <PublishUrl>$(PublishDir)</PublishUrl>
-      <PublishDir>$(IntermediateOutputPath)PubTmp\</PublishDir>
+      <PublishDir Condition="'$(ElectronPublishDir)' != ''">$(ElectronPublishDir)</PublishDir>
+      <PublishDir Condition="'$(ElectronPublishDir)' == ''">$(IntermediateOutputPath)PubTmp\</PublishDir>
     </PropertyGroup>
 
     <RemoveDir Directories="$(PublishDir);$(PublishUrl)" Condition="'$(UsingMicrosoftNETSdkWeb)' != 'true'" />
@@ -385,7 +392,7 @@
       <ElectronPlatform Condition="'$(ElectronRuntimeIdentifier)' == 'win-x64' OR '$(ElectronRuntimeIdentifier)' == 'win-x86' OR '$(ElectronRuntimeIdentifier)' == 'win-arm64'">win</ElectronPlatform>
       <ElectronPlatform Condition="'$(ElectronRuntimeIdentifier)' == 'linux-x64' OR '$(ElectronRuntimeIdentifier)' == 'linux-arm' OR '$(ElectronRuntimeIdentifier)' == 'linux-arm64'">linux</ElectronPlatform>
       <ElectronPlatform Condition="'$(ElectronRuntimeIdentifier)' == 'osx-x64' OR '$(ElectronRuntimeIdentifier)' == 'osx-arm64'">mac</ElectronPlatform>
-     
+
       <!-- npm uses different OS names than Electron -->
       <NpmOs Condition="'$(ElectronPlatform)' == 'win'">win32</NpmOs>
       <NpmOs Condition="'$(ElectronPlatform)' == 'linux'">linux</NpmOs>
@@ -394,7 +401,7 @@
       <!-- npm CPU is same as ElectronArch except for linux-arm -->
       <NpmCpu>$(ElectronArch)</NpmCpu>
       <NpmCpu Condition="'$(ElectronRuntimeIdentifier)' == 'linux-arm'">arm</NpmCpu>
-     
+
       <_CurrentOSPlatform Condition="$([MSBuild]::IsOSPlatform('Windows'))">win</_CurrentOSPlatform>
       <_CurrentOSPlatform Condition="$([MSBuild]::IsOSPlatform('Linux'))">linux</_CurrentOSPlatform>
       <_CurrentOSPlatform Condition="$([MSBuild]::IsOSPlatform('OSX'))">mac</_CurrentOSPlatform>
@@ -445,7 +452,7 @@
 
     <Message Importance="High" Text="Running command: $(_NpmCmd) in folder:  $(ElectronOutputPath)" Condition="@(_CopiedFiles->Count()) > 0" />
 
-    <Exec Command="$(_NpmCmd)" WorkingDirectory="$(ElectronOutputPath)" Timeout="600000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="@(_CopiedFiles->Count()) > 0">
+    <Exec Command="$(_NpmCmd)" WorkingDirectory="$(ElectronOutputPath)" Timeout="600000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="'$(ElectronSkipExecCommands)' != 'true' AND @(_CopiedFiles->Count()) > 0">
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
     </Exec>
 
@@ -629,7 +636,7 @@ For more information, see: https://github.com/ElectronNET/Electron.NET/wiki/Migr
       <_NpmCmd Condition="'$(IsLinuxWsl)' == 'true'">wsl bash -ic '$(_NpmCmd)'</_NpmCmd>
     </PropertyGroup>
 
-    <Exec Command="$(_NpmCmd)" WorkingDirectory="$(ElectronPublishDirFullPath)" Timeout="600000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="@(CopiedFiles->Count()) > 0">
+    <Exec Command="$(_NpmCmd)" WorkingDirectory="$(ElectronPublishDirFullPath)" Timeout="600000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="'$(ElectronSkipExecCommands)' != 'true' AND @(CopiedFiles->Count()) > 0">
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
     </Exec>
 
@@ -657,7 +664,7 @@ For more information, see: https://github.com/ElectronNET/Electron.NET/wiki/Migr
       <_NpxCmd Condition="'$(IsLinuxWsl)' == 'true'">wsl bash -ic '$(_NpxCmd)'</_NpxCmd>
     </PropertyGroup>
 
-    <Exec Command="$(_NpxCmd)" WorkingDirectory="$(ElectronPublishDirFullPath)" Timeout="1800000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="@(CopiedFiles->Count()) > 0">
+    <Exec Command="$(_NpxCmd)" WorkingDirectory="$(ElectronPublishDirFullPath)" Timeout="1800000" StandardOutputImportance="High" StandardErrorImportance="High" ContinueOnError="false" Condition="'$(ElectronSkipExecCommands)' != 'true' AND @(CopiedFiles->Count()) > 0">
       <Output TaskParameter="ExitCode" PropertyName="ExecExitCode"/>
     </Exec>
 


### PR DESCRIPTION

## Summary

This PR makes the Electron.NET runtime and MSBuild targets support an additional "DotNet-First" packaged app layout and gives packaging builds a few more escape hatches.

### Motivation

Today the runtime probes for the packaged layout `resources/bin/<app>` (Electron-first). When the .NET publish output is the app root and the Electron host is placed under an `electron` subdirectory (DotNet-First), `UnpackagedDetector` mis-identifies the app as unpackaged and `ElectronProcessActive` cannot find the Electron binary.

In addition, `ElectronPackageId`, `Title`, the intermediate `PublishDir`, and the `npm`/`npx` exec steps are hard-coded, which makes it harder to plug Electron.NET into custom packaging pipelines or CI.

### Changes

- **DotNet-First layout detection** in `UnpackagedDetector.CheckUnpackaged2`:
  - If the base directory contains an `electron` subdirectory, treat the app as packaged.
  - Existing `resources/bin` (Electron-first) and `.electron` (development) checks are preserved.

- **DotNet-First binary startup** in `ElectronProcessActive.StartCore`:
  - When `dir/electron` exists, start `electron` from that directory and use it as the working directory.
  - Falls back to the existing `dir.Parent.Parent` logic for the Electron-first layout.

- **Overridable build properties** in `ElectronNET.Core.props`:
  - `ElectronPackageId` and `Title` only default from `MSBuildProjectName` when the properties are not already set.

- **Configurable publish/exec targets** in `ElectronNET.LateImport.targets`:
  - `ElectronPublishDir` can override the intermediate `PublishDir`.
  - `ElectronSkipExecCommands` (default `false`) can suppress `npm`/`npx` execution steps.
  - All `Exec` tasks for `npm`/`npx` now respect `ElectronSkipExecCommands`.

### Files changed

- `src/ElectronNET.API/Runtime/Helpers/UnpackagedDetector.cs`
- `src/ElectronNET.API/Runtime/Services/ElectronProcess/ElectronProcessActive.cs`
- `src/ElectronNET/build/ElectronNET.Core.props`
- `src/ElectronNET/build/ElectronNET.LateImport.targets`